### PR TITLE
Restoring properties files to racm main resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,12 +32,6 @@ docs/_build/
 **/WebContent/WEB-INF/application.properties
 **/WebContent/WEB-INF/version
 
-/components/java/racm/src/main/resources/config.properties
-/components/java/racm/src/main/resources/jobm.properties
-/components/java/racm/src/main/resources/login.properties
-/components/java/racm/src/main/resources/jpa-config.properties
-/components/java/racm/src/main/resources/racm.properties
-/components/java/racm/src/main/resources/runtime.properties
 /components/java/racm/src/main/resources/application.properties
 
 node_modules/

--- a/components/java/racm/src/main/resources/config.properties
+++ b/components/java/racm/src/main/resources/config.properties
@@ -1,0 +1,19 @@
+getGroupsUrl = http://localhost:8080/racm/ugm/rest/groups
+getMyGroupsUrl = http://localhost:8080/racm/ugm/rest/mygroups
+# resources
+getResourcesUrl = http://localhost:8080/racm/rest/resources
+postResourcesUrl = http://localhost:8080/racm/rest/resources
+# needs a POST
+getPrivilegesUrl = http://localhost:8080/racm/rest/privileges
+
+getAllUsersUrl = http://localhost:8080/racm/ugm/rest/users/public
+getAllGroupsUrl = http://localhost:8080/racm/ugm/rest/groups
+submitGroupsUrl = http://localhost:8080/racm/ugm/rest/groups
+manageUserProfileUrl = http://localhost:8080/racm/ugm/rest/user
+# next also used as System ResourceContext::racmEndpoint
+racmBaseUrl = http://localhost:8080/racm/
+# next also used as FileSystem ResourceContext::racmEndpoint
+computeFileVolumesBaseUrl = http://scitest12.pha.jhu.edu/fileservice/
+sciserverLoggingAPIBaseUrl = http://scitest12.pha.jhu.edu/sciserver-logging-api/
+casjobsAPIUrl = http://skyserver.sdss.org/CasJobs/RestApi/
+scitestRacmUrl = http://scitest12.pha.jhu.edu/racm/

--- a/components/java/racm/src/main/resources/jobm.properties
+++ b/components/java/racm/src/main/resources/jobm.properties
@@ -1,0 +1,3 @@
+jobm.admin.user=__jobm__
+jobm.admin.password=*******
+jobm.admin.email=jobm@do.not.send

--- a/components/java/racm/src/main/resources/jpa-config.properties
+++ b/components/java/racm/src/main/resources/jpa-config.properties
@@ -1,0 +1,44 @@
+# -----------------------------------------------------------------------------
+# JPA configuration Properties (jdbc) :
+# -----------------------------------------------------------------------------
+
+
+# -----------------------------------------------------------------------------
+#   Logging levels :
+#
+#        OFF     \u2013 disables logging
+#               You may want to set logging to OFF during production to avoid the overhead of logging.
+#
+#        SEVERE  \u2013 logs exceptions indicating that EclipseLink cannot continue, as well as any exceptions generated during login. This includes a stack trace.
+#        WARNING \u2013 logs exceptions that do not force EclipseLink to stop, including all exceptions not logged with severe level. This does not include a stack trace.
+#        INFO    \u2013 logs the login/logout per sever session, including the user name. After acquiring the session, detailed information is logged.
+#        CONFIG  \u2013 logs only login, JDBC connection, and database information.
+#               You may want to use the CONFIG log level at deployment time.
+#
+#        FINE    \u2013 logs SQL.
+#               You may want to use this log level during debugging and testing, but not at production time.
+#
+#        FINER   \u2013 similar to WARNING. Includes stack trace.
+#               You may want to use this log level during debugging and testing, but not at production time.
+#
+#        FINEST  \u2013 includes additional low level information.
+#               You may want to use this log level during debugging and testing, but not at production time.
+#
+#        ALL  \u2013 logs at the same level as FINEST.
+#
+# -----------------------------------------------------------------------------
+
+eclipselink.logging.level = WARNING
+
+
+# -----------------------------------------------------------------------------
+# JDBC information :
+# -----------------------------------------------------------------------------
+
+javax.persistence.jdbc.driver           = com.microsoft.sqlserver.jdbc.SQLServerDriver
+javax.persistence.jdbc.url              = 
+javax.persistence.jdbc.user                   = 
+javax.persistence.jdbc.password               = 
+
+
+# -----------------------------------------------------------------------------

--- a/components/java/racm/src/main/resources/racm.properties
+++ b/components/java/racm/src/main/resources/racm.properties
@@ -1,0 +1,15 @@
+racm.admin.user=__racm__
+racm.admin.password=*******
+racm.admin.email=racm@do.not.send
+
+
+
+## logging properties
+
+Log.ApplicationHost = scidev03
+# Log.ApplicationName is a string that should uniquely identify the application
+Log.ApplicationName = RACM
+Log.MessagingHost = scitest09.sdss.pha.jhu.edu
+Log.DatabaseQueueName = sciserver.log.database_scitest02
+Log.ExchangeName = sciserver.log_scitest02
+Log.Enabled = true

--- a/components/java/racm/src/main/resources/runtime.properties
+++ b/components/java/racm/src/main/resources/runtime.properties
@@ -1,0 +1,75 @@
+#
+# This file containing the definitions
+# for the runtime properties. 
+# These are given values using the ant @property.value@ mechanism
+# which during the build are set by an ANT filtering mechanism.
+# 
+#--------------------------------------------------
+# Properties describing the project itself.
+#--------------------------------------------------
+# short name of the project, used in file names,hence no whitespace etc
+project.name    = RACM
+
+# long name of the project, used in titles
+project.title   = SciServer Metadata
+
+# version of the project
+project.version = 0.1-20160321
+
+# contact email address of the project
+project.contact = jaiwonk@hotmail.com
+
+
+# indicates whether the runtime is a test. This causes more logging messages to be written
+mode.test       = true
+
+
+#---------------------------------------------------------------------------------------------
+# Properties related to the runtime use of the intermediate representation of the UML model 
+#---------------------------------------------------------------------------------------------
+# file containing the intermediate representation of the model
+intermediate.model.file  = RACM.vo-urp.xml
+
+#------------------------------------------------------------------------
+# Properties related to the XML Schema (XSD) generated for the model
+#------------------------------------------------------------------------
+# remote root schema URL
+# e.g. http://volute.googlecode.com/svn/trunk/projects/theory/snapdm/xsd/SimDB_root.xsd
+root.schema.url = http://sciserver.org/racm/xsd/RACM_root.xsd
+root.schema.location = ./xsd/RACM_root.xsd
+
+# The prefix for IVO identifiers assigned to resources in the repository
+service.ivoid   = ivo://sciserver.org/RACM
+
+
+#-------------------
+# Java properties
+#-------------------
+# root package for generated java code (jaxb / jpa) used in MetaModelFactory; default is "org.ivoa."
+base.package=edu.jhu.
+
+
+#-------------------
+# JPA properties
+#-------------------
+# The name of the JPA persistence unit 
+#
+jpa.persistence.unit = RACM-PU
+
+
+#-------------------
+# JAXB properties
+#-------------------
+# JAXB class path, for use in ModelFactory
+jaxb.classpath = ${jaxb.classpath}
+
+# package where meta model generated from intermediateModel.xsd is generated
+# something like $base.package+"metamodel"
+jaxb.package   = org.ivoa.metamodel
+
+
+#--------------------------------------------
+# TAP properties
+#--------------------------------------------
+tap.metadata.xml.file     = @tap.metadata.xml.file@
+tap.metadata.votable.file = @tap.metadata.votable.file@


### PR DESCRIPTION
Turns out the issue with racm not starting was related to properties that were required but not found resulting in NPE. I haven't traced exactly where and how we can avoid that, but restoring the properties gets us back to a working state and nothing is leaked here.