### PR TITLE
fix ingress path type for rendersvc

### DIFF
--- a/helm/sciserver/templates/rendersvc/rendersvc-ingress.yaml
+++ b/helm/sciserver/templates/rendersvc/rendersvc-ingress.yaml
@@ -39,5 +39,5 @@ spec:
             port:
               number: 8080
         path: /{{ include "sciserver.prefix" . }}render/(.*)
-        pathType: Prefix
+        pathType: ImplementationSpecific
 {{ end -}}


### PR DESCRIPTION
The prefix doesn't (or no longer) allows the replacement pattern in the path