### PR TITLE
add concurrency restriction to pages publish job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
         run: git fetch --tags origin
       - name: Generate helm tarball
         run: make helm REPO=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }} VTAG=${{ needs.build.outputs.VTAG }}
+      - name: move tarball
+        run: |
+          mv helm/build/sciserver-*.tar.gz .
       - name: configure git for helm release
         run: |
           git config user.name "$GITHUB_ACTOR"
@@ -83,7 +86,6 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
           git checkout gh-pages
-          mv helm/build/sciserver-*.tar.gz .
           git add sciserver-*.tar.gz
           git commit -m "upload development helm charts for ${{ github.ref }}"
           git push
@@ -104,8 +106,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: helm-charts
-          path: helm/build/*.tar.gz
-
+          path: sciserver-*.tar.gz
 
   docs:
     name: Build docs with Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: get tags
+        run: git fetch --tags origin
       - name: Generate helm tarball
         run: make helm REPO=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }} VTAG=${{ needs.build.outputs.VTAG }}
       - name: configure git for helm release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
   build:
     name: Build all SciServer components
     runs-on: ubuntu-latest
+    outputs:
+      VTAG: ${{ steps.vtag_output.outputs.VTAG }}
     steps:
       - uses: actions/checkout@v4
       - name: get tags
@@ -43,10 +45,34 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/metadata-action@v5
         id: dockermeta
+      - name: Store version tag
+        id: vtag_output
+        run:
+          echo VTAG=${{ fromJSON(steps.dockermeta.outputs.json).labels['org.opencontainers.image.version'] }} >> $GITHUB_OUTPUT
       - name: Build and push docker images
-        run: make publish-images REPO=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }} VTAG=${{ fromJSON(steps.dockermeta.outputs.json).labels['org.opencontainers.image.version'] }}
+        run: make publish-images REPO=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }} VTAG=${{ steps.vtag_output.outputs.VTAG }}
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-reports
+          path: components/java/**/build/reports/tests/test/
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: checkstyle-reports
+          path: components/java/**/build/reports/checkstyle/
+
+  helm:
+    needs: build
+    name: publish helm charts
+    concurrency:
+      group: helm-charts-publication
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Generate helm tarball
-        run: make helm REPO=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }} VTAG=${{ fromJSON(steps.dockermeta.outputs.json).labels['org.opencontainers.image.version'] }}
+        run: make helm REPO=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }} VTAG=${{ needs.build.outputs.VTAG }}
       - name: configure git for helm release
         run: |
           git config user.name "$GITHUB_ACTOR"
@@ -77,16 +103,7 @@ jobs:
         with:
           name: helm-charts
           path: helm/build/*.tar.gz
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test-reports
-          path: components/java/**/build/reports/tests/test/
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: checkstyle-reports
-          path: components/java/**/build/reports/checkstyle/
+
 
   docs:
     name: Build docs with Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,6 @@ jobs:
         run: git fetch --tags origin
       - name: Generate helm tarball
         run: make helm REPO=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }} VTAG=${{ needs.build.outputs.VTAG }}
-      - name: move tarball
-        run: |
-          mv helm/build/sciserver-*.tar.gz .
       - name: configure git for helm release
         run: |
           git config user.name "$GITHUB_ACTOR"
@@ -86,6 +83,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
           git checkout gh-pages
+          mv helm/build/sciserver-*.tar.gz .
           git add sciserver-*.tar.gz
           git commit -m "upload development helm charts for ${{ github.ref }}"
           git push
@@ -103,10 +101,6 @@ jobs:
           packages_with_index: true
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: helm-charts
-          path: sciserver-*.tar.gz
 
   docs:
     name: Build docs with Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ follow the below instructions.
 
 First checkout the repository locally:
 
-```
+```sh
 git clone https://github.com/sciserver/opensciserver.git
 # or for ssh
 # git clone git@github.com:sciserver/opensciserver.git


### PR DESCRIPTION
Limit to a single gh pages helm upload at a time.

This PR separates the helm build/publish into a separate job so that it can leverage the concurrency groups feature of gihub actions. Since the publication job checks out and updates the pages branch, there is a possible race condition when multiple builds are happening at the same time, resulting in all but one failing the push step. The concurrency group should resolve that.