### PR TITLE
Hotfix/make job start time nullable

### DIFF
--- a/components/ui/graphql/src/generated/schema.graphql
+++ b/components/ui/graphql/src/generated/schema.graphql
@@ -149,7 +149,7 @@ type Job {
   dockerComputeResourceContextUUID: UUID
   dockerImageName: String!
   duration: Float!
-  endTime: DateTime!
+  endTime: DateTime
   executorDID: String
   fullDockerCommand: [String!]!
   id: ID!
@@ -157,7 +157,7 @@ type Job {
   resultsFolderURI: String!
   runByUUID: String
   scriptURI: String
-  startTime: DateTime!
+  startTime: DateTime
   status: JobStatus!
   submissionTime: DateTime!
   submitterDID: String!

--- a/components/ui/graphql/src/generated/typings.ts
+++ b/components/ui/graphql/src/generated/typings.ts
@@ -178,7 +178,7 @@ export type Job = {
   dockerComputeResourceContextUUID?: Maybe<Scalars['UUID']>;
   dockerImageName: Scalars['String'];
   duration: Scalars['Float'];
-  endTime: Scalars['DateTime'];
+  endTime?: Maybe<Scalars['DateTime']>;
   executorDID?: Maybe<Scalars['String']>;
   fullDockerCommand: Array<Scalars['String']>;
   id: Scalars['ID'];
@@ -186,7 +186,7 @@ export type Job = {
   resultsFolderURI: Scalars['String'];
   runByUUID?: Maybe<Scalars['String']>;
   scriptURI?: Maybe<Scalars['String']>;
-  startTime: Scalars['DateTime'];
+  startTime?: Maybe<Scalars['DateTime']>;
   status: JobStatus;
   submissionTime: Scalars['DateTime'];
   submitterDID: Scalars['String'];
@@ -675,7 +675,7 @@ export type JobResolvers<ContextType = Context, ParentType extends ResolversPare
   dockerComputeResourceContextUUID?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
   dockerImageName?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   duration?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  endTime?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  endTime?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   executorDID?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   fullDockerCommand?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
@@ -683,7 +683,7 @@ export type JobResolvers<ContextType = Context, ParentType extends ResolversPare
   resultsFolderURI?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   runByUUID?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scriptURI?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  startTime?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  startTime?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   status?: Resolver<ResolversTypes['JobStatus'], ParentType, ContextType>;
   submissionTime?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   submitterDID?: Resolver<ResolversTypes['String'], ParentType, ContextType>;

--- a/components/ui/graphql/src/types/jobs.ts
+++ b/components/ui/graphql/src/types/jobs.ts
@@ -22,8 +22,6 @@ export const typeDefs = gql`
     id: ID!
     submitterDID: String!
     submissionTime: DateTime!
-    startTime: DateTime!
-    endTime: DateTime!
     duration: Float!
     messages: [JobMessage!]!
     status: JobStatus!
@@ -35,6 +33,8 @@ export const typeDefs = gql`
     dockerComputeEndpoint: String!
     dockerImageName: String!
     fullDockerCommand: [String!]!
+    startTime: DateTime
+    endTime: DateTime
     runByUUID: String
     timeout: Int
     dockerComputeResourceContextUUID: UUID

--- a/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
+++ b/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
@@ -196,7 +196,7 @@ export const JobFullDetail: FC<Props> = ({ job, back }) => {
             Started:
           </Typography>
           <Typography variant="body1" gutterBottom component="div">
-            {new Date(job.startTime).toLocaleString()}
+            {job.startTime ? new Date(job.startTime).toLocaleString() : 'N/A'}
           </Typography>
         </div>
         <div className="job-field">
@@ -204,7 +204,7 @@ export const JobFullDetail: FC<Props> = ({ job, back }) => {
             Ended:
           </Typography>
           <Typography variant="body1" gutterBottom component="div">
-            {new Date(job.endTime).toLocaleString()}
+            {job.endTime ? new Date(job.endTime).toLocaleString() : 'N/A'}
           </Typography>
         </div>
       </div>

--- a/components/ui/web/components/content/jobs/detail/jobShortDetail.tsx
+++ b/components/ui/web/components/content/jobs/detail/jobShortDetail.tsx
@@ -92,7 +92,7 @@ export const JobShortDetail: FC<Props> = ({ job, isOpen, selectJob }) => {
                   Started:
                 </Typography>
                 <Typography variant="body1" gutterBottom component="div">
-                  {new Date(job.startTime).toLocaleString()}
+                  {job.startTime ? new Date(job.startTime).toLocaleString() : 'N/A'}
                 </Typography>
               </div>
               <div className="job-field">
@@ -100,7 +100,7 @@ export const JobShortDetail: FC<Props> = ({ job, isOpen, selectJob }) => {
                   Ended:
                 </Typography>
                 <Typography variant="body1" gutterBottom component="div">
-                  {new Date(job.endTime).toLocaleString()}
+                  {job.endTime ? new Date(job.endTime).toLocaleString() : 'N/A'}
                 </Typography>
               </div>
             </div>


### PR DESCRIPTION
## Description

Start and end time fields for Jobs can be null. This change handles these cases on graphql and web components. 