### PR TITLE
add git commit hash as docker tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,11 @@ rendersvc.image: python
 	cd components/python/rendersvc && docker build $(DOCKER_BUILD_OPTS) -t $(REPO)/rendersvc:$(VTAG) -f docker/Dockerfile .
 
 PUSH_TARGETS=$(addsuffix .push,$(IMAGE_COMPONENTS)) keystone.push dashboard.push dashboard-build.push web.push graphql.push rendersvc.push
+HASHTAG=$(shell git rev-parse --short=7 HEAD)
 %.push: %.image
+	docker tag $(REPO)/$(subst .push,,$@):$(VTAG) $(REPO)/$(subst .push,,$@):$(HASHTAG)
 	docker push $(REPO)/$(subst .push,,$@):$(VTAG)
+	docker push $(REPO)/$(subst .push,,$@):$(HASHTAG)
 
 images: $(IMAGE_TARGETS)
 


### PR DESCRIPTION
In addition to tagging images with `pr-`, `main`, and release tags `v*`, we also tag with the git commit hash of the current HEAD, which is a more stable tag, particularly in the case of `main`. 