### PR TITLE
Add support for Ceph user volumes (through PVC)

### DIFF
--- a/components/java/compute/src/org/sciserver/compute/core/container/KubernetesExecutableManager2.java
+++ b/components/java/compute/src/org/sciserver/compute/core/container/KubernetesExecutableManager2.java
@@ -258,7 +258,8 @@ public class KubernetesExecutableManager2 extends ContainerManager implements Ex
         }
     }
 
-    private void addVolumes(String source, String dest, Boolean ro, List<V1Volume> vols, List<V1VolumeMount> mounts) throws Exception {
+    private void addVolumes(String source, String dest, Boolean ro, List<V1Volume> vols, List<V1VolumeMount> mounts)
+            throws Exception {
         Pattern pattern = Pattern.compile("(.*)://([^/]+)/(.*)");
         Matcher matcher = pattern.matcher(source);
         if (matcher.find()) {
@@ -271,43 +272,42 @@ public class KubernetesExecutableManager2 extends ContainerManager implements Ex
             V1VolumeMount volumeMount = null;
             
             switch (type) {
-            case "nfs":
-                volume = new V1VolumeBuilder()
-                        .withName(name)
-                        .withNewNfs()
-                            .withServer(srv)
-                            .withPath(path)
+                case "nfs":
+                    volume = new V1VolumeBuilder()
+                            .withName(name)
+                            .withNewNfs()
+                                .withServer(srv)
+                                .withPath(path)
+                                .withReadOnly(ro)
+                            .endNfs()
+                            .build();
+                    volumeMount = new V1VolumeMountBuilder()
+                            .withName(name)
+                            .withMountPath(dest)
                             .withReadOnly(ro)
-                        .endNfs()
-                        .build();
-                volumeMount = new V1VolumeMountBuilder()
-                        .withName(name)
-                        .withMountPath(dest)
-                        .withReadOnly(ro)
-                        .build();
-                break;
-            case "pvc":
-                volume = new V1VolumeBuilder()
-                        .withName(name)
-                        .withNewPersistentVolumeClaim()
-                            .withClaimName(srv)
-                            .endPersistentVolumeClaim()
-                        .build();
-                volumeMount = new V1VolumeMountBuilder()
-                        .withName(name)
-                        .withSubPath(path)
-                        .withMountPath(dest)
-                        .withReadOnly(ro)
-                        .build();
-                break;
-            default:
-                throw new Exception("Unrecognized mount type: " + type);
+                            .build();
+                    break;
+                case "pvc":
+                    volume = new V1VolumeBuilder()
+                            .withName(name)
+                            .withNewPersistentVolumeClaim()
+                                .withClaimName(srv)
+                                .endPersistentVolumeClaim()
+                            .build();
+                    volumeMount = new V1VolumeMountBuilder()
+                            .withName(name)
+                            .withSubPath(path)
+                            .withMountPath(dest)
+                            .withReadOnly(ro)
+                            .build();
+                    break;
+                default:
+                    throw new Exception("Unrecognized mount type: " + type);
             }
             
             vols.add(volume);
             mounts.add(volumeMount);
-        }
-        else {
+        } else {
             throw new Exception("Cannot parse mount source: " + source);
         }
     }

--- a/components/java/compute/src/org/sciserver/compute/core/container/KubernetesExecutableManager2.java
+++ b/components/java/compute/src/org/sciserver/compute/core/container/KubernetesExecutableManager2.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.sciserver.authentication.client.AuthenticatedUser;
 import org.sciserver.compute.AppConfig;
 import org.sciserver.compute.core.registry.Container;


### PR DESCRIPTION
This will allow using two different mount types for user volumes, similar to public volumes.

Direct NFS mounts (this already existed, and was in fact the only available option)
```
nfs://<server_name>/<path>
```

PVC mounts
```
pvc://<persistent_claim_name>/<path>
```

Root volumes must use this format to specify `pathOnCD`. For example:
```
        "rootVolumes": [
            {
                "id": 10036,
                "pathOnCD": "nfs://sciscratch01/srv/xfs/Temporary/users",
                "displayName": "Temporary",
                "rootVolumeId": 1
            },
            {
                "id": 10037,
                "pathOnCD": "nfs://sciscratch01/srv/xfs/Storage/users",
                "displayName": "Storage",
                "rootVolumeId": 2
            },
            {
                "id": 10038,
                "pathOnCD": "pvc://sciserver-uservolumes-01-static-pvc/users",
                "displayName": "Ceph",
                "rootVolumeId": 3
            }
        ]
```