### PR TITLE
change tar.gz to tgz to match helm releaser, add helm for git hash, u…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: get tags
         run: git fetch --tags origin
-      - name: Generate helm tarball
+      - name: Generate hash-version helm tarball (non-release builds only)
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          short_hash=$(git rev-parse --short=7 HEAD)
+          make helm REPO=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }} VTAG=g${short_hash}
+      - name: Generate tagged-version helm tarball
         run: make helm REPO=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }} VTAG=${{ needs.build.outputs.VTAG }}
       - name: configure git for helm release
         run: |
@@ -83,8 +88,8 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
           git checkout gh-pages
-          mv helm/build/sciserver-*.tar.gz .
-          git add sciserver-*.tar.gz
+          mv helm/build/sciserver-*.tgz .
+          git add sciserver-*.tgz
           git commit -m "upload development helm charts for ${{ github.ref }}"
           git push
       - name: swap built helm charts for release builds

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Mainline commits, pull-requests and tagged versions have built artifacts
 available on the github container registry with tags matching the version. Helm
 charts are likewise published for each of the above to a github pages site at
 
-https://sciserver.github.io/opensciserver/sciserver-{version}.tar.gz
+https://sciserver.github.io/opensciserver/sciserver-{version}.tgz
 
 where `{version}` is either a semver version (such as `1.0.0`) for release
 installs or `pr-{pr-number}` where `{pr-number}` is the pull request number
@@ -54,13 +54,25 @@ helm -n {namespace} \
   --set proxy.cidrWhiteList=0.0.0.0/0 \
   --set dev.nopvc=true \
   -f https://sciserver.github.io/opensciserver/helm/sciserver/password-manifest.yaml \
-  https://sciserver.github.io/opensciserver/sciserver-{version}.tar.gz
+  https://sciserver.github.io/opensciserver/sciserver-{version}.tgz
 ```
 
 replace `{namespace}`, `{name}` and `{domain-name}` Some options above (such as
 the logging api replica count) are there due to incompleteness of this repo, or
 needs fixing. Once this is installed, the dashboard will be available at
 `https://{domain-name}/{name}`!
+
+### Stable non-release tags
+
+If for any reason it is necessary to install a non-release version, we publish
+container images and helm charts tagged with the git commit hash to provide a
+stable artifact (e.g. as opposed to `main`).
+
+The helm release for these has the form
+`https://sciserver.github.io/opensciserver/sciserver-g{git-short-hash}`, where
+`{git-short-hash}` is the first seven characters of the git commit hash (e.g.
+`74971a5`, can be found in the commit list on github or using the `git log`
+command line tool or similar)
 
 ### From a local build of the charts
 
@@ -88,7 +100,7 @@ make helm REPO=ghcr.io/sciserver/opensciserver VTAG=main
 The above will build the helm chart where images are located in the official
 github container registry for opensciserver and we want those built from the
 latest commit to main. This will place the zipped chart under
-`helm/build/sciserver-{VTAG}.tar.gz`, which can be directly specified to helm as
+`helm/build/sciserver-{VTAG}.tgz`, which can be directly specified to helm as
 the chart source (see below). To reference a pull request, simply replace `VTAG`
 as appropriate (`pr-` plus the pull request number):
 

--- a/helm/build.sh
+++ b/helm/build.sh
@@ -22,4 +22,4 @@ sed -i="" "s%<<<HELM_CHART_VERSION>>>%${HELM_CHART_VERSION}%" Chart.yaml
 rm *=
 
 cd ..
-COPYFILE_DISABLE=1 tar -czf sciserver-${VTAG}.tar.gz --no-xattrs sciserver
+COPYFILE_DISABLE=1 tar -czf sciserver-${VTAG}.tgz --no-xattrs sciserver


### PR DESCRIPTION
This PR addresses two things:
* There is some inconsistency between how the release helm chart is published and the PR/main commits, the publication tool writes to `.tgz` extension, whereas other was publishing to `.tar.gz`, since we have easier control over the non-release, this commit just updates to match the release extension.
* We publish images tagged with the commit hash, so we should also publish helm charts using those tags. These tags are more stable than using a name such as main (which constantly changes). This commit adds that