### PR TITLE
make swagger ui docs public

### DIFF
--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/SecurityConfiguration.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/SecurityConfiguration.java
@@ -38,12 +38,12 @@ public class SecurityConfiguration {
 
 	// These endpoints use cookies for authentication
 	private static final String[] webPaths = new String[] {
-			"/", "/index_list.html", "/static/**", ACCESS_DENIED_PAGE,
-			"/compm/mvc/**", "/query/**", "/cctree/**", "/rctree/**"};
+		"/", "/index_list.html", "/static/**", ACCESS_DENIED_PAGE,
+		"/compm/mvc/**", "/query/**", "/cctree/**", "/rctree/**"};
 	// These endpoints are used by compm's, file services, etc and handle their own authentication
 	private static final String[] NON_USER_ENDPOINTS = new String[] {
-			"/jobm/rest/compmdockerjob/*", "/jobm/rest/compm/checkId", "/jobm/rest/compmjob/*", "/jobm/rest/compmjobs/*",
-			"/jobm/rest/rdbjob/*", "/storem/fileservice/*", "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**"
+		"/jobm/rest/compmdockerjob/*", "/jobm/rest/compm/checkId", "/jobm/rest/compmjob/*", "/jobm/rest/compmjobs/*",
+		"/jobm/rest/rdbjob/*", "/storem/fileservice/*", "/swagger-ui/**", "/v3/api-docs", "/v3/api-docs/**"
 	};
 
 	@Bean


### PR DESCRIPTION
Make the racm api docs available without credentials.

Note that the paths technically can be changed via properties. We could use these properties and add patterns to support that - this change keeps it simple and supports only the defaults to be accessible without auth, which seems like a fine trade-off.

Resolves #59