### PR TITLE
Release 05/01

### DIFF
--- a/components/ui/web/components/content/newComputeSession/newComputeSessionForm.tsx
+++ b/components/ui/web/components/content/newComputeSession/newComputeSessionForm.tsx
@@ -10,7 +10,7 @@ import {
   ListSubheader,
   TextField
 } from '@mui/material';
-import { MoreHoriz as MoreHorizIcon, StarBorder as StarBorderIcon } from '@mui/icons-material';
+import { MoreHoriz as MoreHorizIcon } from '@mui/icons-material';
 
 import { DataVolume, Domain, Image, UserVolume } from 'src/graphql/typings';
 
@@ -78,9 +78,6 @@ export const NewComputeSessionForm: FC<Props> = ({
           <ListItem
             secondaryAction={
               <>
-                <IconButton aria-label="star">
-                  <StarBorderIcon />
-                </IconButton>
                 <IconButton aria-label="more options">
                   <MoreHorizIcon />
                 </IconButton>
@@ -106,9 +103,6 @@ export const NewComputeSessionForm: FC<Props> = ({
           <ListItem
             secondaryAction={
               <>
-                <IconButton aria-label="star">
-                  <StarBorderIcon />
-                </IconButton>
                 <IconButton aria-label="more options">
                   <MoreHorizIcon />
                 </IconButton>
@@ -137,9 +131,6 @@ export const NewComputeSessionForm: FC<Props> = ({
             <ListItem
               secondaryAction={
                 <>
-                  <IconButton aria-label="star">
-                    <StarBorderIcon />
-                  </IconButton>
                   <IconButton aria-label="more options">
                     <MoreHorizIcon />
                   </IconButton>
@@ -163,21 +154,16 @@ export const NewComputeSessionForm: FC<Props> = ({
           {userVolumesChoice.map(uv =>
             <ListItem
               secondaryAction={
-                <>
-                  <IconButton aria-label="star">
-                    <StarBorderIcon />
-                  </IconButton>
-                  <IconButton aria-label="more options">
-                    <MoreHorizIcon />
-                  </IconButton>
-                </>
+                <IconButton aria-label="more options">
+                  <MoreHorizIcon />
+                </IconButton>
               }
             >
               <ListItemAvatar>
                 <Avatar alt="Sciserver Logo" src={logo.src} />
               </ListItemAvatar>
               <ListItemText
-                primary={uv.name}
+                primary={`${uv.name} (${uv.owner})`}
                 secondary={uv.description || ''}
               />
             </ListItem>

--- a/components/ui/web/components/content/newComputeSession/userVolumeOptions.tsx
+++ b/components/ui/web/components/content/newComputeSession/userVolumeOptions.tsx
@@ -105,7 +105,7 @@ export const UserVolumeOptions: FC<Props> = ({ userVolumeList, userVolumesChoice
                   <OptionCard
                     key={uv.id}
                     selected={userVolumesChoice.some(uvc => uvc.id === uv.id)}
-                    title={uv.name}
+                    title={`${uv.name} (${uv.owner})`}
                     description={uv.description || 'No description available'}
                     action={() => handleOnClickOption(uv)}
                   />
@@ -128,7 +128,7 @@ export const UserVolumeOptions: FC<Props> = ({ userVolumeList, userVolumesChoice
             <OptionCard
               key={uv.id}
               selected={userVolumesChoice.some(uvc => uvc.id === uv.id)}
-              title={uv.name}
+              title={`${uv.name} (${uv.owner})`}
               description={uv.description || 'No description available'}
               action={() => handleOnClickOption(uv)}
             />

--- a/helm/sciserver/templates/web/web-deployment.yaml
+++ b/helm/sciserver/templates/web/web-deployment.yaml
@@ -69,6 +69,10 @@ spec:
               value: '{{ .Values.web.helpdeskEmail }}'
             - name: NEXT_PUBLIC_JOB_WORKSPACE_PATH
               value: '{{ .Values.web.jobWorkspacePath }}'
+            - name: NEXT_PUBLIC_NEW_JOB_DOMAIN_NAME_DEFAULT
+              value: '{{ .Values.web.newJobDefaults.domainName }}'
+            - name: NEXT_PUBLIC_NEW_JOB_IMAGE_NAME_DEFAULT
+              value: '{{ .Values.web.newJobDefaults.imageName }}'
           ports:
             - containerPort: 3000
               protocol: TCP

--- a/helm/sciserver/values.yaml
+++ b/helm/sciserver/values.yaml
@@ -451,6 +451,9 @@ web:
     domainName: "Interactive Docker Compute Domain"
     imageName: "Sciserver Essentials 4.0"
     quickStartConfig: "dom=Interactive%20Docker%20Compute%20Domain&img=SciServer%20Essentials%204.0&dvs=97"
+  newJobDefaults:
+    domainName: "Small Jobs Domain"
+    imageName: "SciServer Essentials 4.0"
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
This pull request makes several UI and configuration improvements to the compute session creation flow. The main changes include simplifying the volume selection UI by removing the star icon, enhancing clarity by displaying the owner of each user volume, and introducing new Helm configuration options for default job domain and image names.

**UI improvements:**

* Removed the `StarBorderIcon` from the secondary actions in the user volume and options lists within `newComputeSessionForm.tsx`, simplifying the interface. [[1]](diffhunk://#diff-8b5b0a29a80a25847376a33bc35a2a4f064e7a1f78ea8cead2a8c1b02053e603L81-L83) [[2]](diffhunk://#diff-8b5b0a29a80a25847376a33bc35a2a4f064e7a1f78ea8cead2a8c1b02053e603L109-L111) [[3]](diffhunk://#diff-8b5b0a29a80a25847376a33bc35a2a4f064e7a1f78ea8cead2a8c1b02053e603L140-L142) [[4]](diffhunk://#diff-8b5b0a29a80a25847376a33bc35a2a4f064e7a1f78ea8cead2a8c1b02053e603L166-R166)
* Updated the display of user volumes to include the owner in both the main form (`newComputeSessionForm.tsx`) and the options component (`userVolumeOptions.tsx`), making it easier to distinguish between volumes. [[1]](diffhunk://#diff-8b5b0a29a80a25847376a33bc35a2a4f064e7a1f78ea8cead2a8c1b02053e603L166-R166) [[2]](diffhunk://#diff-11171c78b74daeb4e3228afd6c280ee9922d3b2fff10bf61e1908184eea8c3f1L108-R108) [[3]](diffhunk://#diff-11171c78b74daeb4e3228afd6c280ee9922d3b2fff10bf61e1908184eea8c3f1L131-R131)

**Configuration enhancements:**

* Added new default values for job domain and image names (`newJobDefaults.domainName` and `newJobDefaults.imageName`) in the Helm chart values (`values.yaml`) and passed them as environment variables to the web deployment (`web-deployment.yaml`). This allows for easier customization of default job settings. [[1]](diffhunk://#diff-e9c6b4abb816ce503b18d119722f628c017fe3ce3301b124dbfe3ea90065dec2R454-R456) [[2]](diffhunk://#diff-2c87caa7128129a1262b2bfe37d77c8a024a81dbd51774375611058dca625358R72-R75)