### PR TITLE
Fix globus callback URL to include prefix in web deployment

### DIFF
--- a/components/ui/web/components/content/compute/sessionManagement/containerList.tsx
+++ b/components/ui/web/components/content/compute/sessionManagement/containerList.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable promise/catch-or-return */
 import { FC, useMemo } from 'react';
 import { ApolloError, useQuery } from '@apollo/client';

--- a/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
+++ b/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable promise/no-promise-in-callback */
 import { FC, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';

--- a/components/ui/web/components/content/login/login.tsx
+++ b/components/ui/web/components/content/login/login.tsx
@@ -214,7 +214,7 @@ export const Login: FC = () => {
           size="large"
           onClick={() => {
             const globusURL = `${process.env.NEXT_PUBLIC_LOGIN_PORTAL_URL || ''}keycloak-sso?callbackUrl=${process.env.NEXT_PUBLIC_GLOBUS_CALLBACK_URL || ''}`;
-            router.push(globusURL);
+            window.location.href = globusURL;
           }}
           startIcon={<Image src="https://www.globus.org/assets/images/logo_globus-solid.svg" alt="Globus logo" width="40" height="40" />}
         >

--- a/helm/sciserver/templates/web/web-deployment.yaml
+++ b/helm/sciserver/templates/web/web-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - name: NEXT_PUBLIC_FILE_SERVICE_URL
               value: '{{ include "sciserver.url" . }}fileservice/api/'
             - name: NEXT_PUBLIC_GLOBUS_CALLBACK_URL
-              value: '{{ include "sciserver.url" . }}{{ include "sciserver.prefix" . }}web/login'
+              value: '{{ include "sciserver.url" . }}web/login'
             - name: NEXT_PUBLIC_G_TAG
               value: {{ .Values.web.gTag }}
             - name: NEXT_PUBLIC_BASE_PATH

--- a/helm/sciserver/templates/web/web-deployment.yaml
+++ b/helm/sciserver/templates/web/web-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - name: NEXT_PUBLIC_FILE_SERVICE_URL
               value: '{{ include "sciserver.url" . }}fileservice/api/'
             - name: NEXT_PUBLIC_GLOBUS_CALLBACK_URL
-              value: '{{ include "sciserver.url" . }}web/login'
+              value: '{{ include "sciserver.url" . }}{{ include "sciserver.prefix" . }}web/login'
             - name: NEXT_PUBLIC_G_TAG
               value: {{ .Values.web.gTag }}
             - name: NEXT_PUBLIC_BASE_PATH


### PR DESCRIPTION
This pull request updates the `NEXT_PUBLIC_GLOBUS_CALLBACK_URL` environment variable in the `web-deployment.yaml` Helm template to ensure the correct URL prefix is included for the Globus callback. This change improves routing and compatibility when the application is deployed with a custom path prefix.

- **Configuration Update:**
  * [`helm/sciserver/templates/web/web-deployment.yaml`](diffhunk://#diff-2c87caa7128129a1262b2bfe37d77c8a024a81dbd51774375611058dca625358L51-R51): Modified the value of `NEXT_PUBLIC_GLOBUS_CALLBACK_URL` to include the output of `sciserver.prefix`, ensuring the callback URL correctly handles deployments with a path prefix.