### PR TITLE
Add endpoint to retrieve total count of DockerJob records

### DIFF
--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
@@ -454,7 +454,7 @@ public class JOBM {
     public long queryUserDockerJobsCount(UserProfile user) throws VOURPException {
         TransientObjectManager tom = vourpContext.newTOM();
         String sql = String.format("select count(*) from DockerJob where submitterId=:id");
-        Query q = tom.createNativeQuery(sql).setParameter("id", user.getId());
+        Query q = tom.createNativeQuery(sql).setParameter(1, user.getId());
 
         List<?> rows = tom.executeNativeQuery(q);
         if (rows == null || rows.isEmpty()) {

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
@@ -54,623 +54,623 @@ import edu.jhu.user.User;
 
 @Service
 public class JOBM {
-	private static final String SUBMIT_TIME_COLUMN = "submitTime";
-	private static final String DATETIME_FORMAT="yyyy-MM-dd HH:mm:ss Z";
-	private static final String DATE_FORMAT="yyyy-MM-dd";
-	//valid JobType names
+    private static final String SUBMIT_TIME_COLUMN = "submitTime";
+    private static final String DATETIME_FORMAT="yyyy-MM-dd HH:mm:ss Z";
+    private static final String DATE_FORMAT="yyyy-MM-dd";
+    //valid JobType names
 
-	private final JOBMConfig jobmConfig;
-	private final VOURPContext vourpContext;
-	private final JOBMAccessControl jobmAccessControl;
-	private final RDBDomainManager rdbDomainManager;
-	private final JOBMModelFactory jobmModelFactory;
-	private final LoginPortalAccess loginPortalAccess;
+    private final JOBMConfig jobmConfig;
+    private final VOURPContext vourpContext;
+    private final JOBMAccessControl jobmAccessControl;
+    private final RDBDomainManager rdbDomainManager;
+    private final JOBMModelFactory jobmModelFactory;
+    private final LoginPortalAccess loginPortalAccess;
 
-	@Autowired
-	public JOBM(VOURPContext vourpContext, JOBMAccessControl jobmAccessControl,
-			RDBDomainManager rdbDomainManager, JOBMModelFactory jobmModelFactory,
-			JOBMConfig jobmConfig, LoginPortalAccess loginPortalAccess) {
-		this.jobmConfig = jobmConfig;
-		this.vourpContext = vourpContext;
-		this.jobmAccessControl = jobmAccessControl;
-		this.rdbDomainManager = rdbDomainManager;
-		this.jobmModelFactory = jobmModelFactory;
-		this.loginPortalAccess = loginPortalAccess;
-	}
+    @Autowired
+    public JOBM(VOURPContext vourpContext, JOBMAccessControl jobmAccessControl,
+            RDBDomainManager rdbDomainManager, JOBMModelFactory jobmModelFactory,
+            JOBMConfig jobmConfig, LoginPortalAccess loginPortalAccess) {
+        this.jobmConfig = jobmConfig;
+        this.vourpContext = vourpContext;
+        this.jobmAccessControl = jobmAccessControl;
+        this.rdbDomainManager = rdbDomainManager;
+        this.jobmModelFactory = jobmModelFactory;
+        this.loginPortalAccess = loginPortalAccess;
+    }
 
-	/**
-	 * Creates a trust relation between user and JOBM, determines a trust token and returns that.<br/>
-	 * @param up
-	 * @return
-	 * @throws VOURPException
-	 */
-	private String checkUserTrust(UserProfile up) throws VOURPException {
-		String trustId = up.getTrustId();
-		try {
-			if(trustId == null || trustId.trim().length() == 0){
-					trustId = loginPortalAccess.getTrustId(up.getToken(), jobmConfig.getAdminUser());
-					User u = up.getUser();
-					u.setTrustId(trustId);
-			}
-		} catch(Exception e){
-				throw new VOURPException(e);
-		}
-		return trustId;
-	}
+    /**
+     * Creates a trust relation between user and JOBM, determines a trust token and returns that.<br/>
+     * @param up
+     * @return
+     * @throws VOURPException
+     */
+    private String checkUserTrust(UserProfile up) throws VOURPException {
+        String trustId = up.getTrustId();
+        try {
+            if(trustId == null || trustId.trim().length() == 0){
+                    trustId = loginPortalAccess.getTrustId(up.getToken(), jobmConfig.getAdminUser());
+                    User u = up.getUser();
+                    u.setTrustId(trustId);
+            }
+        } catch(Exception e){
+                throw new VOURPException(e);
+        }
+        return trustId;
+    }
 
-	public String getTrustToken(String trustId) throws IOException {
-			return loginPortalAccess.getTrustedToken(jobmConfig.getAdminUser(), jobmConfig.getAdminPassword(), trustId);
-	}
+    public String getTrustToken(String trustId) throws IOException {
+            return loginPortalAccess.getTrustedToken(jobmConfig.getAdminUser(), jobmConfig.getAdminPassword(), trustId);
+    }
 
-	public void buildTrustIfNeeded(User user, String token) throws IOException {
-		if (user.getTrustId() == null || user.getTrustId().trim().length() == 0) {
-			loginPortalAccess.getTrustId(token, user.getUsername());
-		}
-	}
+    public void buildTrustIfNeeded(User user, String token) throws IOException {
+        if (user.getTrustId() == null || user.getTrustId().trim().length() == 0) {
+            loginPortalAccess.getTrustId(token, user.getUsername());
+        }
+    }
 
-	/**
-	 * Create a new job for a user uploaded jobmodel.<br/>
-	 * Assumption is that JOBMAccessControl has NOT YET been checked already that user is allowed to submit a job.
-	 * @param model
-	 * @param up
-	 * @return
-	 * @throws VOURPException
-	 * @throws RACMException
-	 */
-	public DockerJob newDockerJob(COMPMDockerJobModel model, UserProfile up) throws VOURPException, RACMException {
-		// check whether user is allowed to submit jobs
-		jobmAccessControl.tryUserSubmitJob(up);
-		TransientObjectManager tom = up.getTom();
-		DockerJob job = jobmModelFactory.newDockerJob(model, up);
-		// ensure user has been assigned a trustid.
-		checkUserTrust(up);
-		job.setSubmitter(up.getUser());
-		tom.persist();
-		return job;
-	}
+    /**
+     * Create a new job for a user uploaded jobmodel.<br/>
+     * Assumption is that JOBMAccessControl has NOT YET been checked already that user is allowed to submit a job.
+     * @param model
+     * @param up
+     * @return
+     * @throws VOURPException
+     * @throws RACMException
+     */
+    public DockerJob newDockerJob(COMPMDockerJobModel model, UserProfile up) throws VOURPException, RACMException {
+        // check whether user is allowed to submit jobs
+        jobmAccessControl.tryUserSubmitJob(up);
+        TransientObjectManager tom = up.getTom();
+        DockerJob job = jobmModelFactory.newDockerJob(model, up);
+        // ensure user has been assigned a trustid.
+        checkUserTrust(up);
+        job.setSubmitter(up.getUser());
+        tom.persist();
+        return job;
+    }
 
-	/**
-	 * Create a new job for a user uploaded jobmodel.<br/>
-	 * Assumption is that JOBMAccessControl has NOT YET been checked already that user is allowed to submit a job.
-	 * @param model
-	 * @param up
-	 * @return
-	 * @throws VOURPException
-	 * @throws RACMException
-	 */
-	public RDBJob newRDBJob(RDBJobModel model, UserProfile up) throws VOURPException, RACMException {
-		// check whether user is allowed to submit jobs
-		TransientObjectManager tom = up.getTom();
+    /**
+     * Create a new job for a user uploaded jobmodel.<br/>
+     * Assumption is that JOBMAccessControl has NOT YET been checked already that user is allowed to submit a job.
+     * @param model
+     * @param up
+     * @return
+     * @throws VOURPException
+     * @throws RACMException
+     */
+    public RDBJob newRDBJob(RDBJobModel model, UserProfile up) throws VOURPException, RACMException {
+        // check whether user is allowed to submit jobs
+        TransientObjectManager tom = up.getTom();
 
-		// check whether user is allowed to submit jobs
-		jobmAccessControl.tryUserSubmitJob(up);
-		// check whether user is allowed to connect to this database and query it
-  	boolean ok = rdbDomainManager.canUserQueryDatabaseContext(up, model.getRdbDomainId(), model.getDatabaseContextName());
-  	if(!ok)
-  		throw new VOURPException(VOURPException.UNAUTHORIZED,String.format("User '%s' is not allowed to query database context '%s'",up.getUsername(), model.getDatabaseContextName()));
+        // check whether user is allowed to submit jobs
+        jobmAccessControl.tryUserSubmitJob(up);
+        // check whether user is allowed to connect to this database and query it
+      boolean ok = rdbDomainManager.canUserQueryDatabaseContext(up, model.getRdbDomainId(), model.getDatabaseContextName());
+      if(!ok)
+          throw new VOURPException(VOURPException.UNAUTHORIZED,String.format("User '%s' is not allowed to query database context '%s'",up.getUsername(), model.getDatabaseContextName()));
 
-  	RDBJob job = jobmModelFactory.newRDBJob(model, up);
+      RDBJob job = jobmModelFactory.newRDBJob(model, up);
 
-		// ensure user has been assigned a trustid.
-		checkUserTrust(up);
-		job.setSubmitter(up.getUser());
+        // ensure user has been assigned a trustid.
+        checkUserTrust(up);
+        job.setSubmitter(up.getUser());
         ChangeSet changeSet = tom.newChangeSet();
         changeSet.add(job);
         tom.persistChangeSet(changeSet, true);
-		return job;
-	}
+        return job;
+    }
 
 
-	public COMPMJobModel queryUserJob(Long jobId, UserProfile up){
-		TransientObjectManager tom = vourpContext.newTOM();
-		Job job = getJobBySubmitter(tom, up.getId(), jobId);
- 		return jobmModelFactory.newCOMPMJobModel(job, true);
+    public COMPMJobModel queryUserJob(Long jobId, UserProfile up){
+        TransientObjectManager tom = vourpContext.newTOM();
+        Job job = getJobBySubmitter(tom, up.getId(), jobId);
+         return jobmModelFactory.newCOMPMJobModel(job, true);
 
-	}
-	/**
-	 * Add a cancel
-	 * @param jobId
-	 * @param up
-	 * @return
-	 * @throws VOURPException
-	 */
-	public COMPMJobModel cancelUserJob(Long jobId, UserProfile up) throws VOURPException{
-		TransientObjectManager tom = vourpContext.newTOM();
-		Job job = getJobBySubmitter(tom, up.getId(), jobId);
-		if(job == null)
-			throw new VOURPException(String.format("User '%s' has no access to a job with id %d",up.getUsername(), jobId));
-		if(job.getStatus() < JobStatus.STATUS_FINISHED)
-		{
-			if(job.getStatus() == JobStatus.STATUS_PENDING)
-				job.setStatus(JobStatus.STATUS_CANCELED);
-			boolean wasCancelled = false;
-			for(JobMessage m: job.getMessage())
-				if(m.getLabel() == MessageType.CANCEL){
-					wasCancelled = true;
-					break;
-				}
-			if(!wasCancelled){
-				JobMessage m = new JobMessage(job);
-				m.setLabel(MessageType.CANCEL);
-				tom.persist();
-			}
-		}
- 		return jobmModelFactory.newCOMPMJobModel(job, true);
+    }
+    /**
+     * Add a cancel
+     * @param jobId
+     * @param up
+     * @return
+     * @throws VOURPException
+     */
+    public COMPMJobModel cancelUserJob(Long jobId, UserProfile up) throws VOURPException{
+        TransientObjectManager tom = vourpContext.newTOM();
+        Job job = getJobBySubmitter(tom, up.getId(), jobId);
+        if(job == null)
+            throw new VOURPException(String.format("User '%s' has no access to a job with id %d",up.getUsername(), jobId));
+        if(job.getStatus() < JobStatus.STATUS_FINISHED)
+        {
+            if(job.getStatus() == JobStatus.STATUS_PENDING)
+                job.setStatus(JobStatus.STATUS_CANCELED);
+            boolean wasCancelled = false;
+            for(JobMessage m: job.getMessage())
+                if(m.getLabel() == MessageType.CANCEL){
+                    wasCancelled = true;
+                    break;
+                }
+            if(!wasCancelled){
+                JobMessage m = new JobMessage(job);
+                m.setLabel(MessageType.CANCEL);
+                tom.persist();
+            }
+        }
+         return jobmModelFactory.newCOMPMJobModel(job, true);
 
-	}
+    }
 
-	public COMPMJobModel queryCOMPMJob(Long jobId, long compmId) {
-		TransientObjectManager tom = vourpContext.newTOM();
-		Job job = getJobByCOMPM(tom, compmId, jobId);
- 		return jobmModelFactory.newCOMPMJobModel(job, true);
-	}
+    public COMPMJobModel queryCOMPMJob(Long jobId, long compmId) {
+        TransientObjectManager tom = vourpContext.newTOM();
+        Job job = getJobByCOMPM(tom, compmId, jobId);
+         return jobmModelFactory.newCOMPMJobModel(job, true);
+    }
 
-	private Job getJobByCOMPM(TransientObjectManager tom, long compmId, long jobId) {
-		Query q = tom.createQuery("select j from Job j where j.id = :jobId and j.runBy.id=:compmid")
-				.setParameter("compmid", compmId)
-				.setParameter("jobId", jobId);
-		return tom.queryOne(q, Job.class);
-	}
+    private Job getJobByCOMPM(TransientObjectManager tom, long compmId, long jobId) {
+        Query q = tom.createQuery("select j from Job j where j.id = :jobId and j.runBy.id=:compmid")
+                .setParameter("compmid", compmId)
+                .setParameter("jobId", jobId);
+        return tom.queryOne(q, Job.class);
+    }
 
-	private Job getJobBySubmitter(TransientObjectManager tom, long userId, long jobId) {
-		Query q = tom.createQuery("select j from Job j where j.id = :jobId and j.submitter.id=:userId")
-				.setParameter("userId", userId)
-				.setParameter("jobId", jobId);
-		return tom.queryOne(q, Job.class);
-	}
+    private Job getJobBySubmitter(TransientObjectManager tom, long userId, long jobId) {
+        Query q = tom.createQuery("select j from Job j where j.id = :jobId and j.submitter.id=:userId")
+                .setParameter("userId", userId)
+                .setParameter("jobId", jobId);
+        return tom.queryOne(q, Job.class);
+    }
 
-	/**
-	 * Return a Date for the input string. If any exception is thrown while parsing the string null will be returned.<br/>
-	 * @param sd
-	 * @return
-	 */
-	private static Date toDate(String sd) {
-		 if(sd == null)
-			 return null;
-		SimpleDateFormat formatter = new SimpleDateFormat(DATETIME_FORMAT);
-		try {
-			return formatter.parse(sd);
-		} catch (ParseException e) {
-			formatter = new SimpleDateFormat(DATE_FORMAT);
-			try {
-				return formatter.parse(sd);
-			} catch (ParseException e2) {
-				return null;
-			}
-		}
-	}
+    /**
+     * Return a Date for the input string. If any exception is thrown while parsing the string null will be returned.<br/>
+     * @param sd
+     * @return
+     */
+    private static Date toDate(String sd) {
+         if(sd == null)
+             return null;
+        SimpleDateFormat formatter = new SimpleDateFormat(DATETIME_FORMAT);
+        try {
+            return formatter.parse(sd);
+        } catch (ParseException e) {
+            formatter = new SimpleDateFormat(DATE_FORMAT);
+            try {
+                return formatter.parse(sd);
+            } catch (ParseException e2) {
+                return null;
+            }
+        }
+    }
 
-	/**
-	 * Find all jobs for a user, with specified constraints.
-	 * @param user The user for whom the jobs are queried.
-	 * @param open If true, only open jobs, i.e. status <= FINISHED (FINISHED means not yet confirmed that job is properly destroyed).
-	 * @param top If specified as a positive integer the maximum number of jobs that should be returned. If not specified of <= 0, all jobs are returned
-	 * @param start The earliest date (inclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS. If not specified, no lower bound on date.
-	 * @param end The latest date (exclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS, If not specified, no upper bound on the submit time.
-	 * @return
-	 * @throws VOURPException
-	 */
-	public List<COMPMJobModel> queryUserJobs(UserProfile user, boolean open, int top, String start, String end) throws VOURPException{
-		List<COMPMJobModel> jobs = CollectionUtils.collate(
-				queryUserDockerJobs(user, open, -1, start, end),
-				queryUserRDBJobs(user, open, -1, start, end),
-				(dockerJob, rdbJob) ->
-					-dockerJob.getSubmissionTime().compareTo(rdbJob.getSubmissionTime())
-				);
-		if (top > 0 && top < jobs.size())
-			jobs = jobs.subList(0, top);
+    /**
+     * Find all jobs for a user, with specified constraints.
+     * @param user The user for whom the jobs are queried.
+     * @param open If true, only open jobs, i.e. status <= FINISHED (FINISHED means not yet confirmed that job is properly destroyed).
+     * @param top If specified as a positive integer the maximum number of jobs that should be returned. If not specified of <= 0, all jobs are returned
+     * @param start The earliest date (inclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS. If not specified, no lower bound on date.
+     * @param end The latest date (exclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS, If not specified, no upper bound on the submit time.
+     * @return
+     * @throws VOURPException
+     */
+    public List<COMPMJobModel> queryUserJobs(UserProfile user, boolean open, int top, String start, String end) throws VOURPException{
+        List<COMPMJobModel> jobs = CollectionUtils.collate(
+                queryUserDockerJobs(user, open, -1, start, end),
+                queryUserRDBJobs(user, open, -1, start, end),
+                (dockerJob, rdbJob) ->
+                    -dockerJob.getSubmissionTime().compareTo(rdbJob.getSubmissionTime())
+                );
+        if (top > 0 && top < jobs.size())
+            jobs = jobs.subList(0, top);
 
-		return jobs;
-	}
+        return jobs;
+    }
 
-	public JobQueryResult performJobQuery(
-			UserProfile up, JobQuery jobQuery) {
-		CriteriaBuilder builder = up.getTom().getEntityManager().getCriteriaBuilder();
-		CriteriaQuery<Job> cQuery = builder.createQuery(Job.class);
-		Class<? extends Job> clazz = jobQuery.getType().equals(JobQuery.JobType.DOCKER) ?
-				DockerJob.class : RDBJob.class;
-		Root<? extends Job> job = cQuery.from(clazz);
-		Optional<Instant> submitTimeStart = jobQuery.getSubmitTimeStart();
-		Optional<Instant> submitTimeEnd = jobQuery.getSubmitTimeEnd();
+    public JobQueryResult performJobQuery(
+            UserProfile up, JobQuery jobQuery) {
+        CriteriaBuilder builder = up.getTom().getEntityManager().getCriteriaBuilder();
+        CriteriaQuery<Job> cQuery = builder.createQuery(Job.class);
+        Class<? extends Job> clazz = jobQuery.getType().equals(JobQuery.JobType.DOCKER) ?
+                DockerJob.class : RDBJob.class;
+        Root<? extends Job> job = cQuery.from(clazz);
+        Optional<Instant> submitTimeStart = jobQuery.getSubmitTimeStart();
+        Optional<Instant> submitTimeEnd = jobQuery.getSubmitTimeEnd();
 
-		Predicate predicate = builder.conjunction();
-		predicate = builder.and(predicate,
-				builder.equal(job.get("submitter"), up.getUser()));
-		if (!jobQuery.getJobIds().isEmpty()) {
-			predicate = builder.and(predicate,
-					job.get("id").in(jobQuery.getJobIds()));
-		}
-		if (!jobQuery.getJobStatuses().isEmpty()) {
-			predicate = builder.and(predicate,
-					job.get("status").in(jobQuery.getJobStatuses()));
-		}
-		if (submitTimeStart.isPresent()) {
-			predicate = builder.and(predicate,
-					builder.greaterThan(
-							job.get(SUBMIT_TIME_COLUMN),
-							Date.from(submitTimeStart.get())));
-		}
-		if (submitTimeEnd.isPresent()) {
-			predicate = builder.and(predicate,
-					builder.lessThan(
-							job.get(SUBMIT_TIME_COLUMN),
-							Date.from(submitTimeEnd.get())));
-		}
-		cQuery.select(job).where(predicate);
+        Predicate predicate = builder.conjunction();
+        predicate = builder.and(predicate,
+                builder.equal(job.get("submitter"), up.getUser()));
+        if (!jobQuery.getJobIds().isEmpty()) {
+            predicate = builder.and(predicate,
+                    job.get("id").in(jobQuery.getJobIds()));
+        }
+        if (!jobQuery.getJobStatuses().isEmpty()) {
+            predicate = builder.and(predicate,
+                    job.get("status").in(jobQuery.getJobStatuses()));
+        }
+        if (submitTimeStart.isPresent()) {
+            predicate = builder.and(predicate,
+                    builder.greaterThan(
+                            job.get(SUBMIT_TIME_COLUMN),
+                            Date.from(submitTimeStart.get())));
+        }
+        if (submitTimeEnd.isPresent()) {
+            predicate = builder.and(predicate,
+                    builder.lessThan(
+                            job.get(SUBMIT_TIME_COLUMN),
+                            Date.from(submitTimeEnd.get())));
+        }
+        cQuery.select(job).where(predicate);
 
-		jobQuery.getOrderBy().ifPresent(queryOrder -> {
-			switch (queryOrder) {
-			case ASC_JOB_ID:
-				cQuery.orderBy(builder.asc(job.get("id")));
-				break;
-			case ASC_SUBMIT_TIME:
-				cQuery.orderBy(builder.asc(job.get(SUBMIT_TIME_COLUMN)));
-				break;
-			case DESC_JOB_ID:
-				cQuery.orderBy(builder.desc(job.get("id")));
-				break;
-			case DESC_SUBMIT_TIME:
-				cQuery.orderBy(builder.desc(job.get(SUBMIT_TIME_COLUMN)));
-				break;
-			}
-		});
+        jobQuery.getOrderBy().ifPresent(queryOrder -> {
+            switch (queryOrder) {
+            case ASC_JOB_ID:
+                cQuery.orderBy(builder.asc(job.get("id")));
+                break;
+            case ASC_SUBMIT_TIME:
+                cQuery.orderBy(builder.asc(job.get(SUBMIT_TIME_COLUMN)));
+                break;
+            case DESC_JOB_ID:
+                cQuery.orderBy(builder.desc(job.get("id")));
+                break;
+            case DESC_SUBMIT_TIME:
+                cQuery.orderBy(builder.desc(job.get(SUBMIT_TIME_COLUMN)));
+                break;
+            }
+        });
 
-		TypedQuery<Job> q = up.getTom().getEntityManager().createQuery(cQuery)
-			.setFirstResult(jobQuery.getPageNumber() * jobQuery.getLimit())
-			.setMaxResults(jobQuery.getLimit());
+        TypedQuery<Job> q = up.getTom().getEntityManager().createQuery(cQuery)
+            .setFirstResult(jobQuery.getPageNumber() * jobQuery.getLimit())
+            .setMaxResults(jobQuery.getLimit());
 
-		if (jobQuery.includeDetails()) {
-			job.fetch("message", JoinType.LEFT);
-		}
+        if (jobQuery.includeDetails()) {
+            job.fetch("message", JoinType.LEFT);
+        }
 
-		job.fetch("message", JoinType.LEFT);
-		job.fetch("userVolume", JoinType.LEFT);
-		job.fetch("computeDomain");
-		job.fetch("submitter");
-		job.fetch("runBy", JoinType.LEFT);
+        job.fetch("message", JoinType.LEFT);
+        job.fetch("userVolume", JoinType.LEFT);
+        job.fetch("computeDomain");
+        job.fetch("submitter");
+        job.fetch("runBy", JoinType.LEFT);
 
-		if (jobQuery.getType() == JobType.DOCKER) {
-			job.fetch("image", JoinType.LEFT);
-			job.fetch("requiredVolume");
-		} else if (jobQuery.getType() == JobType.RDB) {
-			job.fetch("databaseContext", JoinType.LEFT);
-			job.fetch("target", JoinType.LEFT);
-		} else {
-			throw new IllegalStateException("Unknown job type: " + jobQuery.getType());
-		}
+        if (jobQuery.getType() == JobType.DOCKER) {
+            job.fetch("image", JoinType.LEFT);
+            job.fetch("requiredVolume");
+        } else if (jobQuery.getType() == JobType.RDB) {
+            job.fetch("databaseContext", JoinType.LEFT);
+            job.fetch("target", JoinType.LEFT);
+        } else {
+            throw new IllegalStateException("Unknown job type: " + jobQuery.getType());
+        }
 
-		return new JobQueryResult(q.getResultList().stream()
-			.map(retrievedJob ->
-				jobmModelFactory.newCOMPMJobModel(retrievedJob, jobQuery.includeDetails()))
-			.collect(toList()));
-	}
+        return new JobQueryResult(q.getResultList().stream()
+            .map(retrievedJob ->
+                jobmModelFactory.newCOMPMJobModel(retrievedJob, jobQuery.includeDetails()))
+            .collect(toList()));
+    }
 
-	/**
-	 * Return statistics about user's jobs still running or finished in the last 'since' hours.<br/>
-	 * @param up
-	 * @param since
-	 * @return
-	 */
-	public Map<Integer, Integer> queryUserJobsStats(UserProfile up, int since){
-		TransientObjectManager tom = up.getTom();
-		
-		HashMap<Integer, Integer> r = new HashMap<Integer,Integer>();
-		String sql = String.format("select status, count(*) as num " + 
-				"  from DockerJob where submitterId=%d " + 
-				"    and (status <= %d or DATEDIFF(HOUR,finishedTime,CURRENT_TIMESTAMP)<=%d) " + 
-				"group by status",up.getId(), JobStatus.STATUS_FINISHED,since);
-		Query q = tom.createNativeQuery(sql);
-		
-		List<?> rows = tom.executeNativeQuery(q);
-		for (Object o : rows) {
-			Object[] row = (Object[])o;
-			r.put((Integer)row[0], (Integer)row[1]);
-		}
-		return r;
-	}
-	/**
-	 * Find all docker jobs for a user, with specified constraints.
-	 * @param user The user for whom the jobs are queried.
-	 * @param open If true, only open jobs, i.e. status <= FINISHED (FINISHED means not yet confirmed that job is properly destroyed).
-	 * @param top If specified as a positive integer the maximum number of jobs that should be returned. If not specified of <= 0, all jobs are returned
-	 * @param start The earliest date (inclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS. If not specified, no lower bound on date.
-	 * @param end The latest date (exclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS, If not specified, no upper bound on the submit time.
-	 * @return
-	 * @throws VOURPException
-	 */
-	public List<COMPMDockerJobModel> queryUserDockerJobs(UserProfile user, boolean open, int top, String start, String end) throws VOURPException{
-		TransientObjectManager tom = vourpContext.newTOM();
-		StringBuilder where = new StringBuilder();
-		if(open)
-			where.append(" AND j.status <= :finished ");
-		Date dstart = toDate(start);
-		if(dstart != null)
-			where.append(" AND j.submitTime >= :start ");
-		Date dend = toDate(end);
-		if(dend != null)
-			where.append(" AND j.submitTime < :end ");
+    /**
+     * Return statistics about user's jobs still running or finished in the last 'since' hours.<br/>
+     * @param up
+     * @param since
+     * @return
+     */
+    public Map<Integer, Integer> queryUserJobsStats(UserProfile up, int since){
+        TransientObjectManager tom = up.getTom();
+        
+        HashMap<Integer, Integer> r = new HashMap<Integer,Integer>();
+        String sql = String.format("select status, count(*) as num " + 
+                "  from DockerJob where submitterId=%d " + 
+                "    and (status <= %d or DATEDIFF(HOUR,finishedTime,CURRENT_TIMESTAMP)<=%d) " + 
+                "group by status",up.getId(), JobStatus.STATUS_FINISHED,since);
+        Query q = tom.createNativeQuery(sql);
+        
+        List<?> rows = tom.executeNativeQuery(q);
+        for (Object o : rows) {
+            Object[] row = (Object[])o;
+            r.put((Integer)row[0], (Integer)row[1]);
+        }
+        return r;
+    }
+    /**
+     * Find all docker jobs for a user, with specified constraints.
+     * @param user The user for whom the jobs are queried.
+     * @param open If true, only open jobs, i.e. status <= FINISHED (FINISHED means not yet confirmed that job is properly destroyed).
+     * @param top If specified as a positive integer the maximum number of jobs that should be returned. If not specified of <= 0, all jobs are returned
+     * @param start The earliest date (inclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS. If not specified, no lower bound on date.
+     * @param end The latest date (exclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS, If not specified, no upper bound on the submit time.
+     * @return
+     * @throws VOURPException
+     */
+    public List<COMPMDockerJobModel> queryUserDockerJobs(UserProfile user, boolean open, int top, String start, String end) throws VOURPException{
+        TransientObjectManager tom = vourpContext.newTOM();
+        StringBuilder where = new StringBuilder();
+        if(open)
+            where.append(" AND j.status <= :finished ");
+        Date dstart = toDate(start);
+        if(dstart != null)
+            where.append(" AND j.submitTime >= :start ");
+        Date dend = toDate(end);
+        if(dend != null)
+            where.append(" AND j.submitTime < :end ");
 
-		Query q = tom.createQuery(
-				"select j from DockerJob j where j.submitter.id=:id "
-				+ where.toString()
-				+ " order by j.submitTime desc")
-				.setParameter("id", user.getId());
+        Query q = tom.createQuery(
+                "select j from DockerJob j where j.submitter.id=:id "
+                + where.toString()
+                + " order by j.submitTime desc")
+                .setParameter("id", user.getId());
 
-		q.setHint(QueryHints.LEFT_FETCH, "j.message");
-		q.setHint(QueryHints.LEFT_FETCH, "j.userVolume.userVolume");
-		q.setHint(QueryHints.LEFT_FETCH, "j.computeDomain.resourceContext");
-		q.setHint(QueryHints.LEFT_FETCH, "j.submitter");
-		q.setHint(QueryHints.LEFT_FETCH, "j.runBy");
-		q.setHint(QueryHints.LEFT_FETCH, "j.image");
-		q.setHint(QueryHints.LEFT_FETCH, "j.requiredVolume.volume.resource");
+        q.setHint(QueryHints.LEFT_FETCH, "j.message");
+        q.setHint(QueryHints.LEFT_FETCH, "j.userVolume.userVolume");
+        q.setHint(QueryHints.LEFT_FETCH, "j.computeDomain.resourceContext");
+        q.setHint(QueryHints.LEFT_FETCH, "j.submitter");
+        q.setHint(QueryHints.LEFT_FETCH, "j.runBy");
+        q.setHint(QueryHints.LEFT_FETCH, "j.image");
+        q.setHint(QueryHints.LEFT_FETCH, "j.requiredVolume.volume.resource");
 
-		if(open)
-			q.setParameter("finished", JobStatus.STATUS_FINISHED);
-		if(dstart != null)
-			q.setParameter("start", dstart);
-		if(dend != null)
-			q.setParameter("end", dend);
+        if(open)
+            q.setParameter("finished", JobStatus.STATUS_FINISHED);
+        if(dstart != null)
+            q.setParameter("start", dstart);
+        if(dend != null)
+            q.setParameter("end", dend);
 
-		List<DockerJob> l = tom.queryJPA(q, DockerJob.class);
-		if (top > 0 && top < l.size())
-			l = l.subList(0, top);
+        List<DockerJob> l = tom.queryJPA(q, DockerJob.class);
+        if (top > 0 && top < l.size())
+            l = l.subList(0, top);
 
-		List<COMPMDockerJobModel> jms = new ArrayList<>();
-		if(l != null){
-			for(DockerJob job : l){
-				COMPMDockerJobModel jm = (COMPMDockerJobModel) jobmModelFactory.newCOMPMJobModel(job, true);
-				jms.add(jm);
-			}
-		}
-		return jms;
-	}
+        List<COMPMDockerJobModel> jms = new ArrayList<>();
+        if(l != null){
+            for(DockerJob job : l){
+                COMPMDockerJobModel jm = (COMPMDockerJobModel) jobmModelFactory.newCOMPMJobModel(job, true);
+                jms.add(jm);
+            }
+        }
+        return jms;
+    }
 
-	public List<COMPMDockerJobModel> queryUserDockerJobs(UserProfile user, boolean open, int top, String start, String end, String labelReg) throws VOURPException{
-		NativeQueryResult r = queryUserDockerJobsNative(user, open, top, start, end, labelReg);
-		// id,status,publisherDID,submitterDID,submitTime,startedTime,finishedTime,duration,resultsFolderURI,command,scriptURI,image,computeDomain
-		ArrayList<COMPMDockerJobModel> jobs = new ArrayList<>();
-		
-		for(Object[] row: r.getRows()) {
-			int i = 0;
-			COMPMDockerJobModel job = new COMPMDockerJobModel((Long)row[i++]);
-			job.setStatus((Integer)row[i++]);
-			job.setPublisherDID((String)row[i++]);
-			job.setSubmitterDID((String)row[i++]);
-			job.setSubmissionTime((Date)row[i++]);
-			job.setStartTime((Date)row[i++]);
-			job.setEndTime((Date)row[i++]);
-			job.setDuration((Double)row[i++]);
-			job.setResultsFolderURI((String)row[i++]);
-			job.setCommand((String)row[i++]);
-			job.setScriptURI((String)row[i++]);
-			job.setDockerImageName((String)row[i++]);
-			job.setDockerComputeEndpoint((String)row[i++]);
-			job.setDockerComputeResourceContextUUID((String)row[i++]);
-			jobs.add(job);
-		}
-		return jobs;
-	}
+    public List<COMPMDockerJobModel> queryUserDockerJobs(UserProfile user, boolean open, int top, String start, String end, String labelReg) throws VOURPException{
+        NativeQueryResult r = queryUserDockerJobsNative(user, open, top, start, end, labelReg);
+        // id,status,publisherDID,submitterDID,submitTime,startedTime,finishedTime,duration,resultsFolderURI,command,scriptURI,image,computeDomain
+        ArrayList<COMPMDockerJobModel> jobs = new ArrayList<>();
+        
+        for(Object[] row: r.getRows()) {
+            int i = 0;
+            COMPMDockerJobModel job = new COMPMDockerJobModel((Long)row[i++]);
+            job.setStatus((Integer)row[i++]);
+            job.setPublisherDID((String)row[i++]);
+            job.setSubmitterDID((String)row[i++]);
+            job.setSubmissionTime((Date)row[i++]);
+            job.setStartTime((Date)row[i++]);
+            job.setEndTime((Date)row[i++]);
+            job.setDuration((Double)row[i++]);
+            job.setResultsFolderURI((String)row[i++]);
+            job.setCommand((String)row[i++]);
+            job.setScriptURI((String)row[i++]);
+            job.setDockerImageName((String)row[i++]);
+            job.setDockerComputeEndpoint((String)row[i++]);
+            job.setDockerComputeResourceContextUUID((String)row[i++]);
+            jobs.add(job);
+        }
+        return jobs;
+    }
 
-	public long queryUserDockerJobsCount(UserProfile user) throws VOURPException {
-		TransientObjectManager tom = vourpContext.newTOM();
-		Query q = tom.createNativeQuery(
+    public long queryUserDockerJobsCount(UserProfile user) throws VOURPException {
+        TransientObjectManager tom = vourpContext.newTOM();
+        Query q = tom.createNativeQuery(
       String.format(
         "select count(*) from DockerJob where submitterId=%d", user.getId()
       )
     );
 
-		List<?> rows = tom.executeNativeQuery(q);
-		if (rows == null || rows.isEmpty()) {
-			return 0L;
-		}
-		return ((Number) rows.get(0)).longValue();
-	}
-	/**
-	 * Find all rdb jobs for a user, with specified constraints.
-	 * @param user The user for whom the jobs are queried.
-	 * @param open If true, only open jobs, i.e. status <= FINISHED (FINISHED means not yet confirmed that job is properly destroyed).
-	 * @param top If specified as a positive integer the maximum number of jobs that should be returned. If not specified of <= 0, all jobs are returned
-	 * @param start The earliest date (inclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS. If not specified, no lower bound on date.
-	 * @param end The latest date (exclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS, If not specified, no upper bound on the submit time.
-	 * @return
-	 * @throws VOURPException
-	 */
-	public List<RDBJobModel> queryUserRDBJobs(UserProfile user, boolean open, int top, String start, String end) throws VOURPException{
-		TransientObjectManager tom = vourpContext.newTOM();
-		StringBuilder where = new StringBuilder();
-		if(open)
-			where.append(" AND j.status <= :finished ");
-		Date dstart = toDate(start);
-		if(dstart != null)
-			where.append(" AND j.submitTime >= :start ");
-		Date dend = toDate(end);
-		if(dend != null)
-			where.append(" AND j.submitTime < :end ");
+        List<?> rows = tom.executeNativeQuery(q);
+        if (rows == null || rows.isEmpty()) {
+            return 0L;
+        }
+        return ((Number) rows.get(0)).longValue();
+    }
+    /**
+     * Find all rdb jobs for a user, with specified constraints.
+     * @param user The user for whom the jobs are queried.
+     * @param open If true, only open jobs, i.e. status <= FINISHED (FINISHED means not yet confirmed that job is properly destroyed).
+     * @param top If specified as a positive integer the maximum number of jobs that should be returned. If not specified of <= 0, all jobs are returned
+     * @param start The earliest date (inclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS. If not specified, no lower bound on date.
+     * @param end The latest date (exclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS, If not specified, no upper bound on the submit time.
+     * @return
+     * @throws VOURPException
+     */
+    public List<RDBJobModel> queryUserRDBJobs(UserProfile user, boolean open, int top, String start, String end) throws VOURPException{
+        TransientObjectManager tom = vourpContext.newTOM();
+        StringBuilder where = new StringBuilder();
+        if(open)
+            where.append(" AND j.status <= :finished ");
+        Date dstart = toDate(start);
+        if(dstart != null)
+            where.append(" AND j.submitTime >= :start ");
+        Date dend = toDate(end);
+        if(dend != null)
+            where.append(" AND j.submitTime < :end ");
 
-		Query q = tom.createQuery(
-				"select j from RDBJob j where j.submitter.id=:id "
-				+ where.toString()
-				+ " order by j.submitTime desc")
-				.setParameter("id", user.getId());
+        Query q = tom.createQuery(
+                "select j from RDBJob j where j.submitter.id=:id "
+                + where.toString()
+                + " order by j.submitTime desc")
+                .setParameter("id", user.getId());
 
-		q.setHint(QueryHints.LEFT_FETCH, "j.message");
-		q.setHint(QueryHints.LEFT_FETCH, "j.userVolume.userVolume");
-		q.setHint(QueryHints.LEFT_FETCH, "j.computeDomain.resourceContext");
-		q.setHint(QueryHints.LEFT_FETCH, "j.submitter");
-		q.setHint(QueryHints.LEFT_FETCH, "j.runBy");
-		q.setHint(QueryHints.LEFT_FETCH, "j.databaseContext");
-		q.setHint(QueryHints.LEFT_FETCH, "j.target");
+        q.setHint(QueryHints.LEFT_FETCH, "j.message");
+        q.setHint(QueryHints.LEFT_FETCH, "j.userVolume.userVolume");
+        q.setHint(QueryHints.LEFT_FETCH, "j.computeDomain.resourceContext");
+        q.setHint(QueryHints.LEFT_FETCH, "j.submitter");
+        q.setHint(QueryHints.LEFT_FETCH, "j.runBy");
+        q.setHint(QueryHints.LEFT_FETCH, "j.databaseContext");
+        q.setHint(QueryHints.LEFT_FETCH, "j.target");
 
-		if(open)
-			q.setParameter("finished", JobStatus.STATUS_FINISHED);
-		if(dstart != null)
-			q.setParameter("start", dstart);
-		if(dend != null)
-			q.setParameter("end", dend);
+        if(open)
+            q.setParameter("finished", JobStatus.STATUS_FINISHED);
+        if(dstart != null)
+            q.setParameter("start", dstart);
+        if(dend != null)
+            q.setParameter("end", dend);
 
-		List<RDBJob> l = tom.queryJPA(q, RDBJob.class);
-		if (top > 0 && top < l.size())
-			l = l.subList(0, top);
+        List<RDBJob> l = tom.queryJPA(q, RDBJob.class);
+        if (top > 0 && top < l.size())
+            l = l.subList(0, top);
 
-		List<RDBJobModel> jms = new ArrayList<>();
-		if(l != null){
-			for(RDBJob job : l){
-				RDBJobModel jm = (RDBJobModel) jobmModelFactory.newCOMPMJobModel(job, true);
-				jms.add(jm);
-			}
-		}
-		return jms;
-	}
+        List<RDBJobModel> jms = new ArrayList<>();
+        if(l != null){
+            for(RDBJob job : l){
+                RDBJobModel jm = (RDBJobModel) jobmModelFactory.newCOMPMJobModel(job, true);
+                jms.add(jm);
+            }
+        }
+        return jms;
+    }
 
-	/**
-	 * Return jobs queues for all batch domains, consisting of information about running and pending jobs.<br/>
-	 * Special entry indicates where a job submitted now by the user would end up in the queue.
-	 * Only the username of the user submitting this request is shown, checksums for others. 
-	 * @param up
-	 * @return
-	 */
-	public NativeQueryResult queryJobsQueues(UserProfile up) {
-	    TransientObjectManager tom = up.getTom();
-	    String columns = "domainName,domainClass,queueId,ranking,username,status,submitTime,startedTime";
-	    Query q = tom.createNativeQuery("select "+columns+" from racm.allJobsQueues(?) order by domainName,queueId,ranking");
-	    q.setParameter(1, up.getUser().getId());
-	    List<?> rows = tom.executeNativeQuery(q);
-	    NativeQueryResult r = new NativeQueryResult();
+    /**
+     * Return jobs queues for all batch domains, consisting of information about running and pending jobs.<br/>
+     * Special entry indicates where a job submitted now by the user would end up in the queue.
+     * Only the username of the user submitting this request is shown, checksums for others. 
+     * @param up
+     * @return
+     */
+    public NativeQueryResult queryJobsQueues(UserProfile up) {
+        TransientObjectManager tom = up.getTom();
+        String columns = "domainName,domainClass,queueId,ranking,username,status,submitTime,startedTime";
+        Query q = tom.createNativeQuery("select "+columns+" from racm.allJobsQueues(?) order by domainName,queueId,ranking");
+        q.setParameter(1, up.getUser().getId());
+        List<?> rows = tom.executeNativeQuery(q);
+        NativeQueryResult r = new NativeQueryResult();
         r.setColumns(columns);
         r.setRows(rows);
         return r;
-	}
-	
-	/**
-	 * Query open jobs for a user.<br/>
-	 * @param userId
-	 * @return
-	 */
-	public List<COMPMJobModel> queryOpenCOMPMJobs(long compmId){
-		TransientObjectManager tom = vourpContext.newTOM();
-		Query q = tom.createQuery("select j from Job j where j.runBy.id=:compmid and j.status <= :finishedStatus");
-		q.setParameter("compmid", compmId).setParameter("finishedStatus", JobStatus.STATUS_FINISHED);
-		List<MetadataObject> l = tom.queryJPA(q);
-		List<COMPMJobModel> jms = new ArrayList<>();
-		for(MetadataObject mo:l){
-			Job job = (Job)mo;
-			COMPMJobModel jm = jobmModelFactory.newCOMPMJobModel(job, true);
-			if(jm != null)
-				jms.add(jm);
-		}
-		return jms;
-	}
-	/**
-	 * Query canceled, unfinished jobs for a COMPM.<br/>
-	 * @param compm
-	 * @return
-	 */
-	public Long[] queryCanceledCOMPMJobs(String compmUUID){
-		TransientObjectManager tom = vourpContext.newTOM();
-		Query q = tom.createNativeQuery("select jobId from racm.CanceledCOMPMJobs(?)");
-		q.setParameter(1, compmUUID);
-		List<?> l = tom.executeNativeQuery(q);
-		Long[] ids = new Long[l.size()];
-		for(int i = 0; i < l.size(); i++){
-			Long id = (Long)l.get(i);
-			ids[i]=id;
-		}
-		return ids;
-	}
-	/**
-	 * Return next N pending Jobs available for the specified COMPM.<br/>
-	 * @param uuid
-	 * @return
-	 * @throws VOURPException
-	 */
-	public List<Job> nextJobs(String compmUUID, long defaultJobTimeout,
-			long defaultJobsPerUser, short maxResults) throws VOURPException {
-		TransientObjectManager tom = vourpContext.newTOM();
-		if(maxResults < 1) maxResults=1;
-		Query jobIdQuery = tom.createNativeQuery(String.format(
-				"SELECT jobId FROM racm.nextJobs('%s',%d,%d,%d,%d) order by ranking",
-				compmUUID, defaultJobTimeout,
-				defaultJobTimeout, maxResults,
-				defaultJobsPerUser));
-		List<String> jobids = tom.executeNativeQuery(jobIdQuery).stream()
-				.map(Object::toString)
-				.collect(toList());
+    }
+    
+    /**
+     * Query open jobs for a user.<br/>
+     * @param userId
+     * @return
+     */
+    public List<COMPMJobModel> queryOpenCOMPMJobs(long compmId){
+        TransientObjectManager tom = vourpContext.newTOM();
+        Query q = tom.createQuery("select j from Job j where j.runBy.id=:compmid and j.status <= :finishedStatus");
+        q.setParameter("compmid", compmId).setParameter("finishedStatus", JobStatus.STATUS_FINISHED);
+        List<MetadataObject> l = tom.queryJPA(q);
+        List<COMPMJobModel> jms = new ArrayList<>();
+        for(MetadataObject mo:l){
+            Job job = (Job)mo;
+            COMPMJobModel jm = jobmModelFactory.newCOMPMJobModel(job, true);
+            if(jm != null)
+                jms.add(jm);
+        }
+        return jms;
+    }
+    /**
+     * Query canceled, unfinished jobs for a COMPM.<br/>
+     * @param compm
+     * @return
+     */
+    public Long[] queryCanceledCOMPMJobs(String compmUUID){
+        TransientObjectManager tom = vourpContext.newTOM();
+        Query q = tom.createNativeQuery("select jobId from racm.CanceledCOMPMJobs(?)");
+        q.setParameter(1, compmUUID);
+        List<?> l = tom.executeNativeQuery(q);
+        Long[] ids = new Long[l.size()];
+        for(int i = 0; i < l.size(); i++){
+            Long id = (Long)l.get(i);
+            ids[i]=id;
+        }
+        return ids;
+    }
+    /**
+     * Return next N pending Jobs available for the specified COMPM.<br/>
+     * @param uuid
+     * @return
+     * @throws VOURPException
+     */
+    public List<Job> nextJobs(String compmUUID, long defaultJobTimeout,
+            long defaultJobsPerUser, short maxResults) throws VOURPException {
+        TransientObjectManager tom = vourpContext.newTOM();
+        if(maxResults < 1) maxResults=1;
+        Query jobIdQuery = tom.createNativeQuery(String.format(
+                "SELECT jobId FROM racm.nextJobs('%s',%d,%d,%d,%d) order by ranking",
+                compmUUID, defaultJobTimeout,
+                defaultJobTimeout, maxResults,
+                defaultJobsPerUser));
+        List<String> jobids = tom.executeNativeQuery(jobIdQuery).stream()
+                .map(Object::toString)
+                .collect(toList());
 
-		if (jobids.isEmpty())
-			return Collections.emptyList();
+        if (jobids.isEmpty())
+            return Collections.emptyList();
 
-		Query jobQuery = tom.createQuery("SELECT j FROM Job j WHERE j.id IN :jobids")
-				.setParameter("jobids", jobids);
+        Query jobQuery = tom.createQuery("SELECT j FROM Job j WHERE j.id IN :jobids")
+                .setParameter("jobids", jobids);
 
-		return tom.queryJPA(jobQuery, Job.class).stream()
-				.sorted(comparing(j -> jobids.indexOf(j.getId().toString())))
-				.collect(toList());
-	}
+        return tom.queryJPA(jobQuery, Job.class).stream()
+                .sorted(comparing(j -> jobids.indexOf(j.getId().toString())))
+                .collect(toList());
+    }
 
-	/**
-	 * Find all docker jobs for a user, with specified constraints.
-	 * @param user The user for whom the jobs are queried.
-	 * @param open If true, only open jobs, i.e. status <= FINISHED (FINISHED means not yet confirmed that job is properly destroyed).
-	 * @param top If specified as a positive integer the maximum number of jobs that should be returned. If not specified of <= 0, all jobs are returned
-	 * @param start The earliest date (inclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS. If not specified, no lower bound on date.
-	 * @param end The latest date (exclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS, If not specified, no upper bound on the submit time.
-	 * @return
-	 * @throws VOURPException
-	 */
-	public NativeQueryResult queryUserDockerJobsNative(UserProfile user, boolean open, int top, String start, String end, String labelReg) throws VOURPException{
-		TransientObjectManager tom = vourpContext.newTOM();
-		
-		NativeQueryResult r = new NativeQueryResult();
-		String columns="id,status,publisherDID,submitterDID,submitTime,startedTime,finishedTime,duration,resultsFolderURI,command,scriptURI,image,computeDomain,dockerComputeResourceContextUUID";
-		r.setColumns(columns);
+    /**
+     * Find all docker jobs for a user, with specified constraints.
+     * @param user The user for whom the jobs are queried.
+     * @param open If true, only open jobs, i.e. status <= FINISHED (FINISHED means not yet confirmed that job is properly destroyed).
+     * @param top If specified as a positive integer the maximum number of jobs that should be returned. If not specified of <= 0, all jobs are returned
+     * @param start The earliest date (inclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS. If not specified, no lower bound on date.
+     * @param end The latest date (exclusive) to search for jobs, in format yyyy-MM-dd hh:mm:ss.SSS, If not specified, no upper bound on the submit time.
+     * @return
+     * @throws VOURPException
+     */
+    public NativeQueryResult queryUserDockerJobsNative(UserProfile user, boolean open, int top, String start, String end, String labelReg) throws VOURPException{
+        TransientObjectManager tom = vourpContext.newTOM();
+        
+        NativeQueryResult r = new NativeQueryResult();
+        String columns="id,status,publisherDID,submitterDID,submitTime,startedTime,finishedTime,duration,resultsFolderURI,command,scriptURI,image,computeDomain,dockerComputeResourceContextUUID";
+        r.setColumns(columns);
 
-		String stop="";
-		if(top > 0) 
-			stop=String.format(" top %d ",top);
+        String stop="";
+        if(top > 0) 
+            stop=String.format(" top %d ",top);
 
-		String sql=String.format("select "+stop+
-				" j.id,j.status,j.publisherDID,j.submitterDID,j.submitTime,j.startedTime,j.finishedTime,j.duration,j.resultsFolderURI,j.command,j.scriptURI"
-				+ " ,i.name as image,d.name as computeDomain,rc.uuid as dockerComputeResourceContextUUID "+
-				" from DockerJob j "+
-				"    join dockercomputedomain d " + 
-				"	 on d.id=j.computeDomainId " + 
-				"    join ResourceContext rc " +
-				"    on rc.id=d.resourceContextId" +
-				"	 join DockerImage i " + 
-				"	 on i.id=j.imageId "+
-				" where j.submitterId=%d ",user.getId());
+        String sql=String.format("select "+stop+
+                " j.id,j.status,j.publisherDID,j.submitterDID,j.submitTime,j.startedTime,j.finishedTime,j.duration,j.resultsFolderURI,j.command,j.scriptURI"
+                + " ,i.name as image,d.name as computeDomain,rc.uuid as dockerComputeResourceContextUUID "+
+                " from DockerJob j "+
+                "    join dockercomputedomain d " + 
+                "     on d.id=j.computeDomainId " + 
+                "    join ResourceContext rc " +
+                "    on rc.id=d.resourceContextId" +
+                "     join DockerImage i " + 
+                "     on i.id=j.imageId "+
+                " where j.submitterId=%d ",user.getId());
 
-		
-		StringBuilder where = new StringBuilder();
-		ArrayList<Object> pars = new ArrayList<Object>();
-		if(labelReg != null && labelReg.trim().length() > 0) {
-			labelReg="%"+labelReg+"%";
-			where.append(" and j.submitterDID like ? ");  // UNCLEAR whether this works, or how parameter should be set. seems unsafe for sql injection to 
-			pars.add(labelReg);
-		}
-		if(open) {
-			where.append(String.format(" AND j.status <= %d ",JobStatus.STATUS_FINISHED));
-		}
-		Date dstart = toDate(start);
-		if(dstart != null) {
-			where.append(" AND j.submitTime >= ? ");
-			pars.add(dstart);
-		}
-		Date dend = toDate(end);
-		if(dend != null) {
-			where.append(" AND j.submitTime < ? ");
-			pars.add(dend);
-		}
-	
-		Query q = tom.createNativeQuery(sql
-				+ where.toString() 
-				+ " order by j.submitTime desc");
-		for(int i = 0; i < pars.size(); i++)
-			q.setParameter(i+1, pars.get(i));
-	
-		r.setRows(tom.executeNativeQuery(q));
-		return r;
-	}
+        
+        StringBuilder where = new StringBuilder();
+        ArrayList<Object> pars = new ArrayList<Object>();
+        if(labelReg != null && labelReg.trim().length() > 0) {
+            labelReg="%"+labelReg+"%";
+            where.append(" and j.submitterDID like ? ");  // UNCLEAR whether this works, or how parameter should be set. seems unsafe for sql injection to 
+            pars.add(labelReg);
+        }
+        if(open) {
+            where.append(String.format(" AND j.status <= %d ",JobStatus.STATUS_FINISHED));
+        }
+        Date dstart = toDate(start);
+        if(dstart != null) {
+            where.append(" AND j.submitTime >= ? ");
+            pars.add(dstart);
+        }
+        Date dend = toDate(end);
+        if(dend != null) {
+            where.append(" AND j.submitTime < ? ");
+            pars.add(dend);
+        }
+    
+        Query q = tom.createNativeQuery(sql
+                + where.toString() 
+                + " order by j.submitTime desc");
+        for(int i = 0; i < pars.size(); i++)
+            q.setParameter(i+1, pars.get(i));
+    
+        r.setRows(tom.executeNativeQuery(q));
+        return r;
+    }
 }
 
 

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
@@ -450,6 +450,21 @@ public class JOBM {
 		}
 		return jobs;
 	}
+
+	public long queryUserDockerJobsCount(UserProfile user) throws VOURPException {
+		TransientObjectManager tom = vourpContext.newTOM();
+		Query q = tom.createNativeQuery(
+      String.format(
+        "select count(*) from DockerJob where submitterId=%d", user.getId()
+      )
+    );
+
+		List<?> rows = tom.executeNativeQuery(q);
+		if (rows == null || rows.isEmpty()) {
+			return 0L;
+		}
+		return ((Number) rows.get(0)).longValue();
+	}
 	/**
 	 * Find all rdb jobs for a user, with specified constraints.
 	 * @param user The user for whom the jobs are queried.
@@ -657,3 +672,5 @@ public class JOBM {
 		return r;
 	}
 }
+
+

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
@@ -455,8 +455,8 @@ public class JOBM {
         TransientObjectManager tom = vourpContext.newTOM();
         Query q = tom.createNativeQuery(
       String.format(
-        "select count(*) from DockerJob where submitterId=%d", user.getId()
-      )
+        "select count(*) from DockerJob where submitterId=:id"
+      ).setParameter("id", user.getId())
     );
 
         List<?> rows = tom.executeNativeQuery(q);

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
@@ -453,7 +453,7 @@ public class JOBM {
 
     public long queryUserDockerJobsCount(UserProfile user) throws VOURPException {
         TransientObjectManager tom = vourpContext.newTOM();
-        String sql = String.format("select count(*) from DockerJob where submitterId=:id");
+        String sql = String.format("select count(*) from DockerJob where submitterId=?");
         Query q = tom.createNativeQuery(sql).setParameter(1, user.getId());
 
         List<?> rows = tom.executeNativeQuery(q);

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
@@ -453,11 +453,8 @@ public class JOBM {
 
     public long queryUserDockerJobsCount(UserProfile user) throws VOURPException {
         TransientObjectManager tom = vourpContext.newTOM();
-        Query q = tom.createNativeQuery(
-      String.format(
-        "select count(*) from DockerJob where submitterId=:id"
-      ).setParameter("id", user.getId())
-    );
+        Query q = tom.createQuery("select count(*) from DockerJob where submitterId=:id")
+                .setParameter("id", user.getId());
 
         List<?> rows = tom.executeNativeQuery(q);
         if (rows == null || rows.isEmpty()) {

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBM.java
@@ -453,8 +453,8 @@ public class JOBM {
 
     public long queryUserDockerJobsCount(UserProfile user) throws VOURPException {
         TransientObjectManager tom = vourpContext.newTOM();
-        Query q = tom.createQuery("select count(*) from DockerJob where submitterId=:id")
-                .setParameter("id", user.getId());
+        String sql = String.format("select count(*) from DockerJob where submitterId=:id");
+        Query q = tom.createNativeQuery(sql).setParameter("id", user.getId());
 
         List<?> rows = tom.executeNativeQuery(q);
         if (rows == null || rows.isEmpty()) {

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/controller/JOBMRESTController.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/controller/JOBMRESTController.java
@@ -57,497 +57,497 @@ import edu.jhu.user.UserGroup;
 @RestController
 @RequestMapping("jobm/rest")
 public class JOBMRESTController {
-	public static final String X_SERVICE_ID = "X-Service-Auth-ID";
+    public static final String X_SERVICE_ID = "X-Service-Auth-ID";
 
-	private final COMPMManager compmManager;
-	private final JOBM jobm;
-	private final JsonAPIHelper jsonAPIHelper;
-	private final ObjectMapper om;
-	private final JOBMModelFactory jobmModelFactory;
-	private final DockerComputeDomainManager dockerComputeDomainManager;
-	private final UsersAndGroupsManager usersAndGroupsManager;
+    private final COMPMManager compmManager;
+    private final JOBM jobm;
+    private final JsonAPIHelper jsonAPIHelper;
+    private final ObjectMapper om;
+    private final JOBMModelFactory jobmModelFactory;
+    private final DockerComputeDomainManager dockerComputeDomainManager;
+    private final UsersAndGroupsManager usersAndGroupsManager;
 
-	@Autowired
-	public JOBMRESTController(COMPMManager compmManager, JOBM jobm, JsonAPIHelper jsonAPIHelper,
-			JOBMModelFactory jobmModelFactory, DockerComputeDomainManager dockerComputeDomainManager,
-			UsersAndGroupsManager usersAndGroupsManager) {
-		this.compmManager = compmManager;
-		this.jobm = jobm;
-		this.om = RACMUtil.newObjectMapper();
-		this.jsonAPIHelper = jsonAPIHelper;
-		this.jobmModelFactory = jobmModelFactory;
-		this.dockerComputeDomainManager = dockerComputeDomainManager;
-		this.usersAndGroupsManager = usersAndGroupsManager;
-	}
+    @Autowired
+    public JOBMRESTController(COMPMManager compmManager, JOBM jobm, JsonAPIHelper jsonAPIHelper,
+            JOBMModelFactory jobmModelFactory, DockerComputeDomainManager dockerComputeDomainManager,
+            UsersAndGroupsManager usersAndGroupsManager) {
+        this.compmManager = compmManager;
+        this.jobm = jobm;
+        this.om = RACMUtil.newObjectMapper();
+        this.jsonAPIHelper = jsonAPIHelper;
+        this.jobmModelFactory = jobmModelFactory;
+        this.dockerComputeDomainManager = dockerComputeDomainManager;
+        this.usersAndGroupsManager = usersAndGroupsManager;
+    }
 
-	/**
-	 * Return list of "my" jobs with status.<br/>
-	 * Use ...?all or ...?open t ask for open jobs or all jobs
-	 * filtering, e.g. between two times.
-	 *
-	 * @return
-	 */
-	@GetMapping("/jobs")
-	public ResponseEntity<JsonNode> queryUserJobs(@RequestParam(required = false) String open,
-			@RequestParam(required = false, defaultValue="-1") int top, @RequestParam(required = false) String start,
-			@RequestParam(required = false) String end, @AuthenticationPrincipal UserProfile up) {
-		try {
+    /**
+     * Return list of "my" jobs with status.<br/>
+     * Use ...?all or ...?open t ask for open jobs or all jobs
+     * filtering, e.g. between two times.
+     *
+     * @return
+     */
+    @GetMapping("/jobs")
+    public ResponseEntity<JsonNode> queryUserJobs(@RequestParam(required = false) String open,
+            @RequestParam(required = false, defaultValue="-1") int top, @RequestParam(required = false) String start,
+            @RequestParam(required = false) String end, @AuthenticationPrincipal UserProfile up) {
+        try {
 
-			List<COMPMJobModel> jms = jobm.queryUserJobs(up, open != null, top, start, end);
-			return jsonAPIHelper.success(jms);
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error querying user jobs", Optional.of(up), e, true);
-		}
-	}
+            List<COMPMJobModel> jms = jobm.queryUserJobs(up, open != null, top, start, end);
+            return jsonAPIHelper.success(jms);
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error querying user jobs", Optional.of(up), e, true);
+        }
+    }
 
-	/**
-	 * Return the total number of DockerJob records.
-	 *
-	 * @return
-	 */
-	@GetMapping("/jobs/count")
-	public ResponseEntity<JsonNode> queryDockerJobsCount(@AuthenticationPrincipal UserProfile up) {
-		try {
-			long count = jobm.queryUserDockerJobsCount(up);
-			return jsonAPIHelper.success(count);
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error querying docker jobs count", Optional.of(up), e, true);
-		}
-	}
+    /**
+     * Return the total number of DockerJob records.
+     *
+     * @return
+     */
+    @GetMapping("/jobs/count")
+    public ResponseEntity<JsonNode> queryDockerJobsCount(@AuthenticationPrincipal UserProfile up) {
+        try {
+            long count = jobm.queryUserDockerJobsCount(up);
+            return jsonAPIHelper.success(count);
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error querying docker jobs count", Optional.of(up), e, true);
+        }
+    }
 
-	/**
-	 * Return list of "my" jobs with status.<br/>
-	 * Use ...?all or ...?open t ask for open jobs or all jobs
-	 * filtering, e.g. between two times.
-	 *
-	 * @return
-	 */
-	@GetMapping("/dockerjobs")
-	public ResponseEntity<JsonNode> queryUserDockerJobs(@RequestParam(required = false) String open,
-			@RequestParam(required = false, defaultValue="-1") int top,
-			@RequestParam(required = false) String start,
-			@RequestParam(required = false) String end, @RequestParam(required=false) String labelReg, @AuthenticationPrincipal UserProfile up) {
-		try {
-			List<COMPMDockerJobModel> jms = jobm.queryUserDockerJobs(up, open != null, top, start, end,labelReg);
-			return jsonAPIHelper.success(jms);
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error querying docker jobs", Optional.of(up), e, true);
-		}
-	}
+    /**
+     * Return list of "my" jobs with status.<br/>
+     * Use ...?all or ...?open t ask for open jobs or all jobs
+     * filtering, e.g. between two times.
+     *
+     * @return
+     */
+    @GetMapping("/dockerjobs")
+    public ResponseEntity<JsonNode> queryUserDockerJobs(@RequestParam(required = false) String open,
+            @RequestParam(required = false, defaultValue="-1") int top,
+            @RequestParam(required = false) String start,
+            @RequestParam(required = false) String end, @RequestParam(required=false) String labelReg, @AuthenticationPrincipal UserProfile up) {
+        try {
+            List<COMPMDockerJobModel> jms = jobm.queryUserDockerJobs(up, open != null, top, start, end,labelReg);
+            return jsonAPIHelper.success(jms);
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error querying docker jobs", Optional.of(up), e, true);
+        }
+    }
 
-	/**
-	 * Return statistics about jobs finished less than 'since' hours before the present, or that have not yet finished.<br/>
-	 * @param since number of hours before current time over which statistics is desired. default=24
-	 * @param up
-	 * @return
-	 */
-	@GetMapping("/jobsstats")
-	public ResponseEntity<JsonNode> queryUserJobsStats(@RequestParam(required=false) Integer since, @AuthenticationPrincipal UserProfile up) {
-		try {
-			if(since == null || since < 0) since=24;
-			Map<Integer,Integer> js = jobm.queryUserJobsStats(up, since);
-			return jsonAPIHelper.success(js);
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error querying jobs stats", Optional.of(up), e, true);
-		}
-	}
-	@GetMapping("/dockerjobsold")
-	public ResponseEntity<JsonNode> queryUserDockerJobsOld(@RequestParam(required = false) String open,
-			@RequestParam(required = false, defaultValue="-1") int top,
-			@RequestParam(required = false) String start,
-			@RequestParam(required = false) String end, @AuthenticationPrincipal UserProfile up) {
-		try {
-			List<COMPMDockerJobModel> jms = jobm.queryUserDockerJobs(up, open != null, top, start, end);
-			return jsonAPIHelper.success(jms);
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error querying docker jobs", Optional.of(up), e, true);
-		}
-	}
+    /**
+     * Return statistics about jobs finished less than 'since' hours before the present, or that have not yet finished.<br/>
+     * @param since number of hours before current time over which statistics is desired. default=24
+     * @param up
+     * @return
+     */
+    @GetMapping("/jobsstats")
+    public ResponseEntity<JsonNode> queryUserJobsStats(@RequestParam(required=false) Integer since, @AuthenticationPrincipal UserProfile up) {
+        try {
+            if(since == null || since < 0) since=24;
+            Map<Integer,Integer> js = jobm.queryUserJobsStats(up, since);
+            return jsonAPIHelper.success(js);
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error querying jobs stats", Optional.of(up), e, true);
+        }
+    }
+    @GetMapping("/dockerjobsold")
+    public ResponseEntity<JsonNode> queryUserDockerJobsOld(@RequestParam(required = false) String open,
+            @RequestParam(required = false, defaultValue="-1") int top,
+            @RequestParam(required = false) String start,
+            @RequestParam(required = false) String end, @AuthenticationPrincipal UserProfile up) {
+        try {
+            List<COMPMDockerJobModel> jms = jobm.queryUserDockerJobs(up, open != null, top, start, end);
+            return jsonAPIHelper.success(jms);
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error querying docker jobs", Optional.of(up), e, true);
+        }
+    }
 
-	
-	@GetMapping("/dockerjobs/quick")
-	public ResponseEntity<JsonNode> queryUserDockerJobsNative(@RequestParam(required = false) String open,
-			@RequestParam(required = false, defaultValue="-1") int top,
-			@RequestParam(required = false) String start,
-			@RequestParam(required = false) String end, @RequestParam(required=false) String labelReg, @AuthenticationPrincipal UserProfile up) {
-		try {
-			NativeQueryResult jms = jobm.queryUserDockerJobsNative(up, open != null, top, start, end, labelReg);
-			return jsonAPIHelper.success(jms);
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error querying docker jobs (natively)", Optional.of(up), e, true);
-		}
-	}
-	/**
-	 * Return list of "my" rdb jobs with status.<br/>
-	 * Use ...?open t ask for only open jobs
-	 * filtering, e.g. between two times.
-	 *
-	 */
-	@GetMapping("/rdbjobs")
-	public ResponseEntity<JsonNode> queryUserRdbJobs(
-			@RequestParam(required = false) String open,
-			@RequestParam(defaultValue = "-1", required = false) int top,
-			@RequestParam(required = false) String start,
-			@RequestParam(required = false) String end,
-			@AuthenticationPrincipal UserProfile up) {
-		try {
-			return jsonAPIHelper.success(
-					jobm.queryUserRDBJobs(up, open != null, top, start, end)
-					);
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error obtaining rdb jobs", Optional.of(up), e, true);
-		}
-	}
+    
+    @GetMapping("/dockerjobs/quick")
+    public ResponseEntity<JsonNode> queryUserDockerJobsNative(@RequestParam(required = false) String open,
+            @RequestParam(required = false, defaultValue="-1") int top,
+            @RequestParam(required = false) String start,
+            @RequestParam(required = false) String end, @RequestParam(required=false) String labelReg, @AuthenticationPrincipal UserProfile up) {
+        try {
+            NativeQueryResult jms = jobm.queryUserDockerJobsNative(up, open != null, top, start, end, labelReg);
+            return jsonAPIHelper.success(jms);
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error querying docker jobs (natively)", Optional.of(up), e, true);
+        }
+    }
+    /**
+     * Return list of "my" rdb jobs with status.<br/>
+     * Use ...?open t ask for only open jobs
+     * filtering, e.g. between two times.
+     *
+     */
+    @GetMapping("/rdbjobs")
+    public ResponseEntity<JsonNode> queryUserRdbJobs(
+            @RequestParam(required = false) String open,
+            @RequestParam(defaultValue = "-1", required = false) int top,
+            @RequestParam(required = false) String start,
+            @RequestParam(required = false) String end,
+            @AuthenticationPrincipal UserProfile up) {
+        try {
+            return jsonAPIHelper.success(
+                    jobm.queryUserRDBJobs(up, open != null, top, start, end)
+                    );
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error obtaining rdb jobs", Optional.of(up), e, true);
+        }
+    }
 
-	@PostMapping("/jobs/query")
-	public ResponseEntity<JsonNode> queryJob(
-			@RequestBody JobQuery query,
-			@AuthenticationPrincipal UserProfile up) {
-		try {
-			return jsonAPIHelper.success(
-					jobm.performJobQuery(up, query));
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error querying jobs", Optional.of(up), e, true);
-		}
-	}
+    @PostMapping("/jobs/query")
+    public ResponseEntity<JsonNode> queryJob(
+            @RequestBody JobQuery query,
+            @AuthenticationPrincipal UserProfile up) {
+        try {
+            return jsonAPIHelper.success(
+                    jobm.performJobQuery(up, query));
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error querying jobs", Optional.of(up), e, true);
+        }
+    }
 
-	/**
-	 * Return info about all queues for all domains.<br/>
-	 * Current jobs, pending jobs and locaton where a job submitted now by the specified user would end up in the queue.
-	 * @param compmuuid
-	 * @param up
-	 * @return
-	 */
+    /**
+     * Return info about all queues for all domains.<br/>
+     * Current jobs, pending jobs and locaton where a job submitted now by the specified user would end up in the queue.
+     * @param compmuuid
+     * @param up
+     * @return
+     */
     @GetMapping("/jobs/queues")
     public NativeQueryResult queryJobsQueues(@AuthenticationPrincipal UserProfile up) {
         return jobm.queryJobsQueues(up);
     }
-	/**
-	 * Return status of specified Job.<br/>
-	 * Only if user is allowed
-	 *
-	 * @param jobId
-	 * @return
-	 */
-	@GetMapping("/jobs/{jobId}")
-	public ResponseEntity<JsonNode> jobStatus(@PathVariable Long jobId, @AuthenticationPrincipal UserProfile up) {
-		COMPMJobModel jm = jobm.queryUserJob(jobId, up);
-		JsonNode json = om.valueToTree(jm);
+    /**
+     * Return status of specified Job.<br/>
+     * Only if user is allowed
+     *
+     * @param jobId
+     * @return
+     */
+    @GetMapping("/jobs/{jobId}")
+    public ResponseEntity<JsonNode> jobStatus(@PathVariable Long jobId, @AuthenticationPrincipal UserProfile up) {
+        COMPMJobModel jm = jobm.queryUserJob(jobId, up);
+        JsonNode json = om.valueToTree(jm);
 
-		LogUtils.buildLog()
-			.forJOBM()
-			.user(up)
-			.sentence()
-				.subject(up.getUsername())
-				.verb("viewed")
-				.predicate("job %d", jm.getId())
-			.extraField("job", jm.getId())
-			.log();
-		return new ResponseEntity<>(json, HttpStatus.OK);
-	}
+        LogUtils.buildLog()
+            .forJOBM()
+            .user(up)
+            .sentence()
+                .subject(up.getUsername())
+                .verb("viewed")
+                .predicate("job %d", jm.getId())
+            .extraField("job", jm.getId())
+            .log();
+        return new ResponseEntity<>(json, HttpStatus.OK);
+    }
 
-	@PostMapping("/jobs/{jobId}/cancel")
-	public ResponseEntity<JsonNode> cancelJob(@PathVariable Long jobId, @AuthenticationPrincipal UserProfile up)
-			throws VOURPException {
-		try {
-			COMPMJobModel jm = jobm.cancelUserJob(jobId, up);
+    @PostMapping("/jobs/{jobId}/cancel")
+    public ResponseEntity<JsonNode> cancelJob(@PathVariable Long jobId, @AuthenticationPrincipal UserProfile up)
+            throws VOURPException {
+        try {
+            COMPMJobModel jm = jobm.cancelUserJob(jobId, up);
 
-			LogUtils.buildLog()
-				.forJOBM()
-				.user(up)
-				.showInUserHistory()
-				.sentence()
-					.subject(up.getUsername())
-					.verb("canceled")
-					.predicate("job %d", jm.getId())
-				.extraField("job", jm.getId())
-				.log();
-			JsonNode json = om.valueToTree(jm);
-			return new ResponseEntity<>(json, HttpStatus.OK);
-		} catch (VOURPException e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error canceling job", Optional.of(up), e, true);
-		}
-	}
+            LogUtils.buildLog()
+                .forJOBM()
+                .user(up)
+                .showInUserHistory()
+                .sentence()
+                    .subject(up.getUsername())
+                    .verb("canceled")
+                    .predicate("job %d", jm.getId())
+                .extraField("job", jm.getId())
+                .log();
+            JsonNode json = om.valueToTree(jm);
+            return new ResponseEntity<>(json, HttpStatus.OK);
+        } catch (VOURPException e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error canceling job", Optional.of(up), e, true);
+        }
+    }
 
-	/**
-	 * Return information about the docker compute domain where a user can at least
-	 * access one docker image.<br/>
-	 * Return the visible images, volume containers and uservolumes that can be
-	 * mountes on the compute domain for the user.
-	 *
-	 * @param batch
-	 * @param interactive
-	 * @param request
-	 * @param response
-	 * @return
-	 * @throws VOURPException
-	 */
-	@GetMapping("/computedomains")
-	public ResponseEntity<JsonNode> queryComputeDomains(@RequestParam(required = false) String batch,
-			@RequestParam(required = false) String interactive, @AuthenticationPrincipal UserProfile up) {
-		try {
-			// rule: if batch is not invluded, only interactive.
-			// if batch is included, only include interactive if explicitly requested
-			boolean includeBatch = (batch != null && "true".equals(batch));
-			boolean includeInteractive = !includeBatch || (interactive != null && "true".equals(interactive));
-			Collection<UserDockerComputeDomainModel> jms = dockerComputeDomainManager.queryUserDockerComputeDomains(up,
-					includeBatch, includeInteractive);
+    /**
+     * Return information about the docker compute domain where a user can at least
+     * access one docker image.<br/>
+     * Return the visible images, volume containers and uservolumes that can be
+     * mountes on the compute domain for the user.
+     *
+     * @param batch
+     * @param interactive
+     * @param request
+     * @param response
+     * @return
+     * @throws VOURPException
+     */
+    @GetMapping("/computedomains")
+    public ResponseEntity<JsonNode> queryComputeDomains(@RequestParam(required = false) String batch,
+            @RequestParam(required = false) String interactive, @AuthenticationPrincipal UserProfile up) {
+        try {
+            // rule: if batch is not invluded, only interactive.
+            // if batch is included, only include interactive if explicitly requested
+            boolean includeBatch = (batch != null && "true".equals(batch));
+            boolean includeInteractive = !includeBatch || (interactive != null && "true".equals(interactive));
+            Collection<UserDockerComputeDomainModel> jms = dockerComputeDomainManager.queryUserDockerComputeDomains(up,
+                    includeBatch, includeInteractive);
 
-			JsonNode json = om.valueToTree(jms);
-			return new ResponseEntity<>(json, HttpStatus.OK);
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error querying compute domains", Optional.of(up), e);
-		}
-	}
-	/**
-	 * Return an admin view of all the registered DockerComputeDomains.<br/>
-	 * User must be an admin to be allowed to access this information.
-	 * @param up
-	 * @return
-	 */
-	@GetMapping("/dockercomputedomains")
-	public ResponseEntity<JsonNode> queryDockerComputeDomains(@AuthenticationPrincipal UserProfile up) {
-		try {
-			if(!up.isAdmin())
-				throw new InsufficientPermissionsException("Illegal request made for admin information about Docker Compute Domains.");
-			List<DockerComputeDomainModel> dcdms = dockerComputeDomainManager.queryDockerComputeDomains(up);
+            JsonNode json = om.valueToTree(jms);
+            return new ResponseEntity<>(json, HttpStatus.OK);
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error querying compute domains", Optional.of(up), e);
+        }
+    }
+    /**
+     * Return an admin view of all the registered DockerComputeDomains.<br/>
+     * User must be an admin to be allowed to access this information.
+     * @param up
+     * @return
+     */
+    @GetMapping("/dockercomputedomains")
+    public ResponseEntity<JsonNode> queryDockerComputeDomains(@AuthenticationPrincipal UserProfile up) {
+        try {
+            if(!up.isAdmin())
+                throw new InsufficientPermissionsException("Illegal request made for admin information about Docker Compute Domains.");
+            List<DockerComputeDomainModel> dcdms = dockerComputeDomainManager.queryDockerComputeDomains(up);
 
-			JsonNode json = om.valueToTree(dcdms);
-			return new ResponseEntity<>(json, HttpStatus.OK);
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error querying docker compute domains", Optional.of(up), e);
-		}
-	}
+            JsonNode json = om.valueToTree(dcdms);
+            return new ResponseEntity<>(json, HttpStatus.OK);
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error querying docker compute domains", Optional.of(up), e);
+        }
+    }
 
-	/**
-	 *
-	 * @param body
-	 * @param admin
-	 *            if set, give admin privileges to the groups in the comma-separated
-	 *            value
-	 * @param read
-	 *            if set, give read privileges to the groups in the comma-separated
-	 *            value
-	 * @param request
-	 * @param response
-	 * @return
-	 * @throws VOURPException
-	 */
-	@PostMapping("/computedomains/docker")
-	public ResponseEntity<JsonNode> registerDockerComputeDomain(@RequestBody String body,
-			@RequestParam(required = false) String admins, @AuthenticationPrincipal UserProfile up) {
-		try {
-			jobm.buildTrustIfNeeded(up.getUser(), up.getToken());
-			DockerComputeDomainModel dcdm;
-			ObjectMapper mapper = RACMUtil.newObjectMapper();
-			ObjectNode node = mapper.readValue(body, ObjectNode.class);
+    /**
+     *
+     * @param body
+     * @param admin
+     *            if set, give admin privileges to the groups in the comma-separated
+     *            value
+     * @param read
+     *            if set, give read privileges to the groups in the comma-separated
+     *            value
+     * @param request
+     * @param response
+     * @return
+     * @throws VOURPException
+     */
+    @PostMapping("/computedomains/docker")
+    public ResponseEntity<JsonNode> registerDockerComputeDomain(@RequestBody String body,
+            @RequestParam(required = false) String admins, @AuthenticationPrincipal UserProfile up) {
+        try {
+            jobm.buildTrustIfNeeded(up.getUser(), up.getToken());
+            DockerComputeDomainModel dcdm;
+            ObjectMapper mapper = RACMUtil.newObjectMapper();
+            ObjectNode node = mapper.readValue(body, ObjectNode.class);
 
-			if (node != null) {
-				dcdm = mapper.convertValue(node, DockerComputeDomainModel.class);
-			} else {
-				throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT, "No valid Json posted to groups endpoint");
-			}
+            if (node != null) {
+                dcdm = mapper.convertValue(node, DockerComputeDomainModel.class);
+            } else {
+                throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT, "No valid Json posted to groups endpoint");
+            }
 
-			TransientObjectManager tom = up.getTom();
-			UserGroup[] adminGroups = usersAndGroupsManager.findGroups(admins, tom);
+            TransientObjectManager tom = up.getTom();
+            UserGroup[] adminGroups = usersAndGroupsManager.findGroups(admins, tom);
 
-			DockerComputeDomain dcd = dockerComputeDomainManager.manageDockerComputeDomain(dcdm, up, adminGroups);
-			tom.persist();
+            DockerComputeDomain dcd = dockerComputeDomainManager.manageDockerComputeDomain(dcdm, up, adminGroups);
+            tom.persist();
 
-			dcdm = jobmModelFactory.newDockerComputeDomainModel(dcd, true);
-			JsonNode json = om.valueToTree(dcdm);
+            dcdm = jobmModelFactory.newDockerComputeDomainModel(dcd, true);
+            JsonNode json = om.valueToTree(dcdm);
 
-			LogUtils.buildLog()
-				.forJOBM()
-				.user(up)
-				.showInUserHistory()
-				.sentence()
-					.subject(up.getUsername())
-					.verb("registered")
-					.predicate("docker compute domain '%s'", dcdm.getName())
-				.extraField("dockerComputeDomain", dcdm.getId())
-				.log();
-			return new ResponseEntity<>(json, HttpStatus.OK);
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error register a docker compute domain", Optional.of(up), e, true);
-		}
-	}
+            LogUtils.buildLog()
+                .forJOBM()
+                .user(up)
+                .showInUserHistory()
+                .sentence()
+                    .subject(up.getUsername())
+                    .verb("registered")
+                    .predicate("docker compute domain '%s'", dcdm.getName())
+                .extraField("dockerComputeDomain", dcdm.getId())
+                .log();
+            return new ResponseEntity<>(json, HttpStatus.OK);
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error register a docker compute domain", Optional.of(up), e, true);
+        }
+    }
 
-	/**
-	 * Submit a docker job
-	 *
-	 * @param jobModel
-	 * @param request
-	 * @param response
-	 * @return
-	 */
-	@PostMapping("/jobs/docker")
-	public ResponseEntity<JsonNode> submitJob(@RequestBody String body, @AuthenticationPrincipal UserProfile up) {
+    /**
+     * Submit a docker job
+     *
+     * @param jobModel
+     * @param request
+     * @param response
+     * @return
+     */
+    @PostMapping("/jobs/docker")
+    public ResponseEntity<JsonNode> submitJob(@RequestBody String body, @AuthenticationPrincipal UserProfile up) {
         String username = up==null?"null":up.getUsername();
-		try {
-			jobm.buildTrustIfNeeded(up.getUser(), up.getToken());
-		} catch(Exception e) {
+        try {
+            jobm.buildTrustIfNeeded(up.getUser(), up.getToken());
+        } catch(Exception e) {
             return jsonAPIHelper.logAndReturnJsonExceptionEntity(
                     "Error retrieving trust ID for user "+username, Optional.of(up), e, true);
-		}		    
+        }            
 
-		try {
-			// every user can in principle *try* to submit a job.
-			ObjectMapper mapper = RACMUtil.newObjectMapper();
-			ObjectNode node = mapper.readValue(body, ObjectNode.class);
-			COMPMDockerJobModel jobModel = null;
+        try {
+            // every user can in principle *try* to submit a job.
+            ObjectMapper mapper = RACMUtil.newObjectMapper();
+            ObjectNode node = mapper.readValue(body, ObjectNode.class);
+            COMPMDockerJobModel jobModel = null;
 
-			if (node != null) {
-				jobModel = mapper.convertValue(node, COMPMDockerJobModel.class);
-			} else {
-				throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT,
-						"Invalid Json posted to /jobs/docker endpoint");
-			}
-			
-			DockerJob job = null;
-			
-			try {
-			    job = jobm.newDockerJob(jobModel, up);
-			} catch(Exception e) {
-			    throw new Exception("Error creating DockerJob\n"+e.getMessage(),e);
-			}
-			COMPMJobModel jm = jobmModelFactory.newCOMPMJobModel(job, true);
+            if (node != null) {
+                jobModel = mapper.convertValue(node, COMPMDockerJobModel.class);
+            } else {
+                throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT,
+                        "Invalid Json posted to /jobs/docker endpoint");
+            }
+            
+            DockerJob job = null;
+            
+            try {
+                job = jobm.newDockerJob(jobModel, up);
+            } catch(Exception e) {
+                throw new Exception("Error creating DockerJob\n"+e.getMessage(),e);
+            }
+            COMPMJobModel jm = jobmModelFactory.newCOMPMJobModel(job, true);
 
-			String jobDescription;
-			if (!TextUtils.isEmpty(job.getPublisherDID())) {
-				jobDescription = job.getPublisherDID();
-			} else if (!TextUtils.isEmpty(job.getScriptURI())) {
-				jobDescription = "notebook '" + job.getScriptURI() + "'";
-			} else {
-				jobDescription = "'" + job.getCommand() + "'";
-			}
+            String jobDescription;
+            if (!TextUtils.isEmpty(job.getPublisherDID())) {
+                jobDescription = job.getPublisherDID();
+            } else if (!TextUtils.isEmpty(job.getScriptURI())) {
+                jobDescription = "notebook '" + job.getScriptURI() + "'";
+            } else {
+                jobDescription = "'" + job.getCommand() + "'";
+            }
 
-			LogUtils.buildLog()
-				.forJOBM()
-				.user(up)
-				.showInUserHistory()
-				.sentence()
-					.subject(up.getUsername())
-					.verb("submitted")
-					.predicate(jobDescription)
-				.extraField("userVolumes", new JSONArray(
-						job.getUserVolume().stream()
-							.map(uv -> uv.getUserVolume().getId()).collect(toList())
-				))
-				.extraField("volumeContainers", new JSONArray(
-						job.getRequiredVolume().stream()
-							.map(vc -> vc.getVolume().getId()).collect(toList())
-				))
-				.extraField("computeDomain", job.getComputeDomain().getId())
-				.extraField("job", job.getId())
-				.extraField("image", job.getImage().getId())
-				.log();
-			return jsonAPIHelper.success(jm);
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error in job submission for user "+username+"\n\t"+e.getMessage(), Optional.of(up), e, true);
-		}
-	}
+            LogUtils.buildLog()
+                .forJOBM()
+                .user(up)
+                .showInUserHistory()
+                .sentence()
+                    .subject(up.getUsername())
+                    .verb("submitted")
+                    .predicate(jobDescription)
+                .extraField("userVolumes", new JSONArray(
+                        job.getUserVolume().stream()
+                            .map(uv -> uv.getUserVolume().getId()).collect(toList())
+                ))
+                .extraField("volumeContainers", new JSONArray(
+                        job.getRequiredVolume().stream()
+                            .map(vc -> vc.getVolume().getId()).collect(toList())
+                ))
+                .extraField("computeDomain", job.getComputeDomain().getId())
+                .extraField("job", job.getId())
+                .extraField("image", job.getImage().getId())
+                .log();
+            return jsonAPIHelper.success(jm);
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error in job submission for user "+username+"\n\t"+e.getMessage(), Optional.of(up), e, true);
+        }
+    }
 
-	/**
-	 * A COMPM registers itself. Must do so with a valid token of a user with the
-	 * right to register COMPMs. Will be assigned a new UUID if it does not include
-	 * this in the registration. Will be known by that uuid from then on and MUST
-	 * use it in future registrations. If the COMPM had been registered before, the
-	 * call will return a JSON message with the jobs owned by the COMPM that are
-	 * still outstanding.
-	 *
-	 * @param request
-	 * @return
-	 */
-	@PostMapping("/compm/register")
-	public ResponseEntity<JsonNode> registerCOMPM(
-			@AuthenticationPrincipal UserProfile up,
-			@RequestBody COMPMModel compmModel) {
-		try {
-			COMPMModel cm = compmManager.createCOMPM(compmModel, up);
+    /**
+     * A COMPM registers itself. Must do so with a valid token of a user with the
+     * right to register COMPMs. Will be assigned a new UUID if it does not include
+     * this in the registration. Will be known by that uuid from then on and MUST
+     * use it in future registrations. If the COMPM had been registered before, the
+     * call will return a JSON message with the jobs owned by the COMPM that are
+     * still outstanding.
+     *
+     * @param request
+     * @return
+     */
+    @PostMapping("/compm/register")
+    public ResponseEntity<JsonNode> registerCOMPM(
+            @AuthenticationPrincipal UserProfile up,
+            @RequestBody COMPMModel compmModel) {
+        try {
+            COMPMModel cm = compmManager.createCOMPM(compmModel, up);
 
-			LogUtils.buildLog()
-				.forJOBM()
-				.user(up)
-				.showInUserHistory()
-				.sentence()
-					.subject(up.getUsername())
-					.verb("registered")
-					.predicate("compm '%s'", cm.getDescription())
-				.extraField("compm", cm.getId())
-				.extraField("computeDomain", cm.getComputeDomainId())
-				.log();
-			return jsonAPIHelper.success(cm);
-		} catch (VOURPException e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error registering a compm", Optional.of(up), e, true);
-		}
-	}
+            LogUtils.buildLog()
+                .forJOBM()
+                .user(up)
+                .showInUserHistory()
+                .sentence()
+                    .subject(up.getUsername())
+                    .verb("registered")
+                    .predicate("compm '%s'", cm.getDescription())
+                .extraField("compm", cm.getId())
+                .extraField("computeDomain", cm.getComputeDomainId())
+                .log();
+            return jsonAPIHelper.success(cm);
+        } catch (VOURPException e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error registering a compm", Optional.of(up), e, true);
+        }
+    }
 
-	/**
-	 * Return list of "casjobs" jobs<br/>
-	 *
-	 * @return
-	 */
-	@GetMapping("/casjobs")
-	public ResponseEntity<JsonNode> queryUserCasJobs(@RequestParam(required = false) String submittedFrom,
-			@RequestParam(required = false) String submittedTo, @AuthenticationPrincipal UserProfile up) {
-		try {
-			String token = up.getToken();
-			HttpRequest casJobsRequest = new HttpRequest();
-			HttpResponseResult casJobsResult;
+    /**
+     * Return list of "casjobs" jobs<br/>
+     *
+     * @return
+     */
+    @GetMapping("/casjobs")
+    public ResponseEntity<JsonNode> queryUserCasJobs(@RequestParam(required = false) String submittedFrom,
+            @RequestParam(required = false) String submittedTo, @AuthenticationPrincipal UserProfile up) {
+        try {
+            String token = up.getToken();
+            HttpRequest casJobsRequest = new HttpRequest();
+            HttpResponseResult casJobsResult;
 
-			Map<String, String> extraHeaderFields = new HashMap<>();
-			extraHeaderFields.put(AUTH_HEADER, token);
+            Map<String, String> extraHeaderFields = new HashMap<>();
+            extraHeaderFields.put(AUTH_HEADER, token);
 
-			String queryString = "submittedFrom=" + submittedFrom + "&submittedTo=" + submittedTo;
+            String queryString = "submittedFrom=" + submittedFrom + "&submittedTo=" + submittedTo;
 
-			casJobsResult = casJobsRequest.executeGet("http://skyserver.sdss.org/CasJobs/RestApi/jobs?" + queryString,
-					extraHeaderFields);
+            casJobsResult = casJobsRequest.executeGet("http://skyserver.sdss.org/CasJobs/RestApi/jobs?" + queryString,
+                    extraHeaderFields);
 
-			if (casJobsResult != null && casJobsResult.getResponseCode() >= 200 && casJobsResult.getResponseCode() <= 299) {
-				LogUtils.buildLog()
-					.forJOBM()
-					.user(up)
-					.sentence()
-						.subject(up.getUsername())
-						.verb("queried")
-						.predicate("CasJobs")
-					.log();
+            if (casJobsResult != null && casJobsResult.getResponseCode() >= 200 && casJobsResult.getResponseCode() <= 299) {
+                LogUtils.buildLog()
+                    .forJOBM()
+                    .user(up)
+                    .sentence()
+                        .subject(up.getUsername())
+                        .verb("queried")
+                        .predicate("CasJobs")
+                    .log();
 
-				String jsonString = casJobsResult.getMessage();
-				JsonNode jsonNode = null;
+                String jsonString = casJobsResult.getMessage();
+                JsonNode jsonNode = null;
 
-				if (jsonString != null && !jsonString.isEmpty()) {
-					jsonNode = om.readTree(jsonString);
-				}
-				return new ResponseEntity<>(jsonNode, HttpStatus.OK);
-			} else {
-				ObjectNode on = om.createObjectNode();
-				on.put("status", "error");
-				if(casJobsResult != null)
-					on.put("error", casJobsResult.getMessage());
-				return new ResponseEntity<>(on,
-						casJobsResult != null ? HttpStatus.valueOf(casJobsResult.getResponseCode()) : HttpStatus.NOT_FOUND);
-			}
+                if (jsonString != null && !jsonString.isEmpty()) {
+                    jsonNode = om.readTree(jsonString);
+                }
+                return new ResponseEntity<>(jsonNode, HttpStatus.OK);
+            } else {
+                ObjectNode on = om.createObjectNode();
+                on.put("status", "error");
+                if(casJobsResult != null)
+                    on.put("error", casJobsResult.getMessage());
+                return new ResponseEntity<>(on,
+                        casJobsResult != null ? HttpStatus.valueOf(casJobsResult.getResponseCode()) : HttpStatus.NOT_FOUND);
+            }
 
-		} catch (Exception e) {
-			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
-					"Error querying casjobs jobs", Optional.of(up), e, true);
-		}
-	}
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error querying casjobs jobs", Optional.of(up), e, true);
+        }
+    }
 
 }

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/controller/JOBMRESTController.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/controller/JOBMRESTController.java
@@ -102,6 +102,22 @@ public class JOBMRESTController {
 	}
 
 	/**
+	 * Return the total number of DockerJob records.
+	 *
+	 * @return
+	 */
+	@GetMapping("/jobs/count")
+	public ResponseEntity<JsonNode> queryDockerJobsCount(@AuthenticationPrincipal UserProfile up) {
+		try {
+			long count = jobm.queryUserDockerJobsCount(up);
+			return jsonAPIHelper.success(count);
+		} catch (Exception e) {
+			return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+					"Error querying docker jobs count", Optional.of(up), e, true);
+		}
+	}
+
+	/**
 	 * Return list of "my" jobs with status.<br/>
 	 * Use ...?all or ...?open t ask for open jobs or all jobs
 	 * filtering, e.g. between two times.

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/controller/JOBMRESTController.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/controller/JOBMRESTController.java
@@ -110,7 +110,9 @@ public class JOBMRESTController {
     public ResponseEntity<JsonNode> queryDockerJobsCount(@AuthenticationPrincipal UserProfile up) {
         try {
             long count = jobm.queryUserDockerJobsCount(up);
-            return jsonAPIHelper.success(count);
+            ObjectNode result = om.createObjectNode();
+            result.put("count", count);
+            return jsonAPIHelper.success(result);
         } catch (Exception e) {
             return jsonAPIHelper.logAndReturnJsonExceptionEntity(
                     "Error querying docker jobs count", Optional.of(up), e, true);


### PR DESCRIPTION
Closes #81 

This pull request adds a new API endpoint to retrieve the total count of Docker jobs for a user. It introduces a backend method to efficiently query the count and exposes it through a REST API in the controller. The main changes are grouped below:

Backend functionality:

* Added a new method `queryUserDockerJobsCount` in `JOBM.java` to query the total number of DockerJob records for a given user using a native SQL count query.

API/Controller updates:

* Added a new REST endpoint `/jobs/count` in `JOBMRESTController.java` that returns the total number of DockerJob records for the authenticated user, handling exceptions and returning a JSON response.

Other:

* Minor formatting/whitespace changes at the end of `JOBM.java`.