### PR TITLE
[HOTFIX] Review and modify rerun action doesn't work

### DIFF
--- a/components/ui/graphql/src/generated/schema.graphql
+++ b/components/ui/graphql/src/generated/schema.graphql
@@ -53,8 +53,12 @@ input CreateJobParams {
   resultsFolderURI: String!
   scriptURI: String!
   submitterDID: String!
-  userVolumes: [ID!]!
-  volumeContainers: [ID!]!
+  userVolumes: [UserVolInput!]!
+  volumeContainers: [DataVolInput!]!
+}
+
+input DataVolInput {
+  name: String!
 }
 
 type DataVolume {
@@ -276,6 +280,11 @@ type User {
   id: ID!
   userName: String!
   visibility: String!
+}
+
+input UserVolInput {
+  needsWriteAccess: Boolean!
+  userVolumeId: ID!
 }
 
 type UserVolume {

--- a/components/ui/graphql/src/generated/typings.ts
+++ b/components/ui/graphql/src/generated/typings.ts
@@ -77,8 +77,12 @@ export type CreateJobParams = {
   resultsFolderURI: Scalars['String'];
   scriptURI: Scalars['String'];
   submitterDID: Scalars['String'];
-  userVolumes: Array<Scalars['ID']>;
-  volumeContainers: Array<Scalars['ID']>;
+  userVolumes: Array<UserVolInput>;
+  volumeContainers: Array<DataVolInput>;
+};
+
+export type DataVolInput = {
+  name: Scalars['String'];
 };
 
 export type DataVolume = {
@@ -388,6 +392,11 @@ export type User = {
   visibility: Scalars['String'];
 };
 
+export type UserVolInput = {
+  needsWriteAccess: Scalars['Boolean'];
+  userVolumeId: Scalars['ID'];
+};
+
 export type UserVolume = {
   __typename?: 'UserVolume';
   allowedActions: Array<Maybe<Scalars['String']>>;
@@ -484,6 +493,7 @@ export type ResolversTypes = {
   ContainerParams: ContainerParams;
   ContainerStatus: ContainerStatus;
   CreateJobParams: CreateJobParams;
+  DataVolInput: DataVolInput;
   DataVolume: ResolverTypeWrapper<DataVolume>;
   Dataset: ResolverTypeWrapper<Dataset>;
   DatasetDetailInput: DatasetDetailInput;
@@ -515,6 +525,7 @@ export type ResolversTypes = {
   URL: ResolverTypeWrapper<Scalars['URL']>;
   UUID: ResolverTypeWrapper<Scalars['UUID']>;
   User: ResolverTypeWrapper<User>;
+  UserVolInput: UserVolInput;
   UserVolume: ResolverTypeWrapper<UserVolume>;
   VolumeType: VolumeType;
 };
@@ -528,6 +539,7 @@ export type ResolversParentTypes = {
   ContainerDetailParams: ContainerDetailParams;
   ContainerParams: ContainerParams;
   CreateJobParams: CreateJobParams;
+  DataVolInput: DataVolInput;
   DataVolume: DataVolume;
   Dataset: Dataset;
   DatasetDetailInput: DatasetDetailInput;
@@ -558,6 +570,7 @@ export type ResolversParentTypes = {
   URL: Scalars['URL'];
   UUID: Scalars['UUID'];
   User: User;
+  UserVolInput: UserVolInput;
   UserVolume: UserVolume;
 };
 

--- a/components/ui/graphql/src/types/jobs.ts
+++ b/components/ui/graphql/src/types/jobs.ts
@@ -60,9 +60,18 @@ export const typeDefs = gql`
     value: String!
   }
 
+  input DataVolInput {
+    name: String!
+  }
+  
+  input UserVolInput {
+    userVolumeId: ID!
+    needsWriteAccess: Boolean!
+  }
+
   input CreateJobParams {
-    volumeContainers: [ID!]!
-    userVolumes: [ID!]!
+    volumeContainers: [DataVolInput!]!
+    userVolumes: [UserVolInput!]!
     command: String!
     resultsFolderURI: String!
     dockerComputeEndpoint: String!

--- a/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
+++ b/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
@@ -160,8 +160,12 @@ export const JobFullDetail: FC = () => {
               dockerImageName: job.dockerImageName,
               resultsFolderURI,
               submitterDID: job.submitterDID,
-              volumeContainers: job.dataVolumes.map(dv => dv.publisherDID),
-              userVolumes: job.userVolumes.map(uv => uv.id),
+              volumeContainers: job.dataVolumes.map(dv => {
+                return { name: dv.name };
+              }),
+              userVolumes: job.userVolumes.map(uv => {
+                return { userVolumeId: uv.id, needsWriteAccess: uv.needsWriteAccess };
+              }),
               command: job.command,
               scriptURI: job.scriptURI || ''
             }

--- a/components/ui/web/components/content/jobs/list/RerunJobAction.tsx
+++ b/components/ui/web/components/content/jobs/list/RerunJobAction.tsx
@@ -44,8 +44,12 @@ export const RerunJobAction: FC<Props> = ({ job, startPolling }) => {
             dockerImageName: job.dockerImageName,
             resultsFolderURI,
             submitterDID: job.submitterDID,
-            volumeContainers: job.dataVolumes.map(dv => dv.publisherDID),
-            userVolumes: job.userVolumes.map(uv => uv.id),
+            volumeContainers: job.dataVolumes.map(dv => {
+              return { name: dv.name };
+            }),
+            userVolumes: job.userVolumes.map(uv => {
+              return { userVolumeId: uv.id, needsWriteAccess: uv.needsWriteAccess };
+            }),
             command: job.command,
             scriptURI: job.scriptURI || ''
           }

--- a/components/ui/web/components/content/jobs/new/newJob.tsx
+++ b/components/ui/web/components/content/jobs/new/newJob.tsx
@@ -65,8 +65,12 @@ export const NewJob: FC = () => {
           resultsFolderURI,
           submitterDID: sessionName,
           scriptURI: '',
-          volumeContainers: dataVolumesChoice.map(dv => dv.publisherDID),
-          userVolumes: userVolumesChoice.map(uv => uv.id),
+          volumeContainers: dataVolumesChoice.map(dv => {
+            return { name: dv.name };
+          }),
+          userVolumes: userVolumesChoice.map(uv => {
+            return { userVolumeId: uv.id, needsWriteAccess: uv.allowedActions.includes('write') };
+          }),
           command
         }
       }

--- a/components/ui/web/components/content/newComputeSession/newComputeSession.tsx
+++ b/components/ui/web/components/content/newComputeSession/newComputeSession.tsx
@@ -157,7 +157,7 @@ export const NewComputeSession: FC<Props> = ({
   const dataVolumeList = useMemo<DataVolume[]>(() => {
     if (domainChoice) {
       if (editJob) {
-        setDataVolumesChoice(editJob.dataVolumes.map(dv => domainChoice.dataVolumes.find(dvl => dvl.id === dv.id)!));
+        setDataVolumesChoice(editJob.dataVolumes.map(dv => domainChoice.dataVolumes.find(dvl => dvl.publisherDID === dv.publisherDID)!));
       }
       return domainChoice.dataVolumes;
     }

--- a/components/ui/web/src/graphql/domains.ts
+++ b/components/ui/web/src/graphql/domains.ts
@@ -18,6 +18,7 @@ export const GET_DOMAINS = gql`
         owner
         description
         rootVolumeName
+        allowedActions
       }
       dataVolumes {
         name

--- a/components/ui/web/src/graphql/jobs.ts
+++ b/components/ui/web/src/graphql/jobs.ts
@@ -16,9 +16,12 @@ export const GET_JOBS = gql`
         submissionTime
         dataVolumes {
           publisherDID
+          name
         }
         userVolumes {
           id
+          userVolumeId
+          needsWriteAccess
         }
       }
       totalJobs
@@ -42,10 +45,12 @@ export const JOB_DETAIL_VIEW = gql`
         dockerComputeEndpoint
         dataVolumes {
           publisherDID
+          name
         }
         userVolumes {
           id
           userVolumeId
+          needsWriteAccess
         }
       }
       summary

--- a/components/ui/web/src/graphql/typings.ts
+++ b/components/ui/web/src/graphql/typings.ts
@@ -80,8 +80,12 @@ export type CreateJobParams = {
   resultsFolderURI: Scalars['String'];
   scriptURI: Scalars['String'];
   submitterDID: Scalars['String'];
-  userVolumes: Array<Scalars['ID']>;
-  volumeContainers: Array<Scalars['ID']>;
+  userVolumes: Array<UserVolInput>;
+  volumeContainers: Array<DataVolInput>;
+};
+
+export type DataVolInput = {
+  name: Scalars['String'];
 };
 
 export type DataVolume = {
@@ -391,6 +395,11 @@ export type User = {
   visibility: Scalars['String'];
 };
 
+export type UserVolInput = {
+  needsWriteAccess: Scalars['Boolean'];
+  userVolumeId: Scalars['ID'];
+};
+
 export type UserVolume = {
   __typename?: 'UserVolume';
   allowedActions: Array<Maybe<Scalars['String']>>;
@@ -487,6 +496,7 @@ export type ResolversTypes = {
   ContainerParams: ContainerParams;
   ContainerStatus: ContainerStatus;
   CreateJobParams: CreateJobParams;
+  DataVolInput: DataVolInput;
   DataVolume: ResolverTypeWrapper<DataVolume>;
   Dataset: ResolverTypeWrapper<Dataset>;
   DatasetDetailInput: DatasetDetailInput;
@@ -518,6 +528,7 @@ export type ResolversTypes = {
   URL: ResolverTypeWrapper<Scalars['URL']>;
   UUID: ResolverTypeWrapper<Scalars['UUID']>;
   User: ResolverTypeWrapper<User>;
+  UserVolInput: UserVolInput;
   UserVolume: ResolverTypeWrapper<UserVolume>;
   VolumeType: VolumeType;
 };
@@ -531,6 +542,7 @@ export type ResolversParentTypes = {
   ContainerDetailParams: ContainerDetailParams;
   ContainerParams: ContainerParams;
   CreateJobParams: CreateJobParams;
+  DataVolInput: DataVolInput;
   DataVolume: DataVolume;
   Dataset: Dataset;
   DatasetDetailInput: DatasetDetailInput;
@@ -561,6 +573,7 @@ export type ResolversParentTypes = {
   URL: Scalars['URL'];
   UUID: Scalars['UUID'];
   User: User;
+  UserVolInput: UserVolInput;
   UserVolume: UserVolume;
 };
 


### PR DESCRIPTION
Update data volume selection logic to use publisherDID for editing jobs

## For testing purposes

Ran a job with command `ls -d ~/workspace/*/*`

### Result file:

<img width="667" height="434" alt="image" src="https://github.com/user-attachments/assets/188c0b42-de20-454f-be64-e5ee7f031b12" />

When clicking the `Review and modify` option, all Data Vols and User vols chosen to create the job in the first place show up

<img width="1285" height="751" alt="image" src="https://github.com/user-attachments/assets/b59782fd-dc85-4bc1-a948-14240e753be5" />
