### PR TITLE
feat(racm): add endpoint to attach a single root volume to a docker compute domain

### DIFF
--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/DockerComputeDomainManager.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/DockerComputeDomainManager.java
@@ -24,11 +24,13 @@ import org.sciserver.springapp.racm.resources.application.ContextClassManager;
 import org.sciserver.springapp.racm.ugm.domain.UserProfile;
 import org.sciserver.springapp.racm.utils.RACMNames;
 import org.sciserver.springapp.racm.utils.RACMUtil;
+import org.sciserver.springapp.racm.utils.controller.ResourceNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import edu.jhu.job.ComputeResource;
 import edu.jhu.job.DockerComputeDomain;
 import edu.jhu.job.DockerImage;
+import edu.jhu.job.RootVolumeOnComputeDomain;
 import edu.jhu.job.VolumeContainer;
 import edu.jhu.rac.ContextClass;
 import edu.jhu.rac.Resource;
@@ -104,6 +106,41 @@ public class DockerComputeDomainManager {
             return createDockerComputeDomain(model, up, admins);
     }
 
+    /**
+     * Attach one root volume to the identified docker compute domain.
+     *
+     * <p>Transaction outside the method, i.e. this method does not persist the TOM.
+     *
+     * @param racmUUID uuid of the compute domain's resource context
+     * @param rvm the root volume to attach
+     * @param up the calling user
+     * @return the newly created RootVolumeOnComputeDomain, already attached to the domain
+     * @throws VOURPException if the user is not authorized or the request is invalid
+     */
+    public RootVolumeOnComputeDomain addRootVolume(String racmUUID,
+            RootVolumeOnComputeDomainModel rvm, UserProfile up) throws VOURPException {
+        TransientObjectManager tom = up.getTom();
+
+        DockerComputeDomain dcd = queryDockerComputeDomainForUUID(racmUUID, tom);
+        if (dcd == null)
+            throw new ResourceNotFoundException(
+                    String.format("No docker compute domain with racmUUID %s", racmUUID));
+
+        if (!jobmAccessControl.canAddRootVolume(up, dcd))
+            throw new VOURPException(VOURPException.UNAUTHORIZED, String.format(
+                    "User %s is not authorized to add a root volume to the compute domain with apiEndpoint '%s'",
+                    up.getUsername(), dcd.getApiEndpoint()));
+
+        validateNewRootVolume(dcd, rvm);
+
+        return jobmModelFactory.newRootVolumeOnComputeDomain(rvm, dcd);
+    }
+
+    private void validateNewRootVolume(DockerComputeDomain dcd,
+            RootVolumeOnComputeDomainModel rvm) throws VOURPException {
+        // Filled in by the next task.
+    }
+
     private DockerComputeDomain queryDockerComputeDomainForEndpoint(String endpoint,
             TransientObjectManager tom) {
         Query q = tom
@@ -121,7 +158,7 @@ public class DockerComputeDomainManager {
         return tom.queryOne(q, DockerComputeDomain.class);
     }
 
-    private DockerComputeDomain queryDockerComputeDomainForUUID(String uuid,
+    DockerComputeDomain queryDockerComputeDomainForUUID(String uuid,
             TransientObjectManager tom) {
         // TODO should we check that user is allowed to see the compute domain? or
         // can everyone see it?

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/DockerComputeDomainManager.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/DockerComputeDomainManager.java
@@ -138,7 +138,52 @@ public class DockerComputeDomainManager {
 
     private void validateNewRootVolume(DockerComputeDomain dcd,
             RootVolumeOnComputeDomainModel rvm) throws VOURPException {
-        // Filled in by the next task.
+        // id is assigned by RACM; supplying one is a client error, not something to ignore
+        if (rvm.getId() != null)
+            throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT,
+                    "id must not be supplied when creating a root volume on a compute domain; "
+                            + "it is assigned by RACM");
+
+        if (rvm.getRootVolumeId() == null)
+            throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT, "rootVolumeId is required");
+        if (isBlank(rvm.getPathOnCD()))
+            throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT, "pathOnCD is required");
+        if (isBlank(rvm.getDisplayName()))
+            throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT, "displayName is required");
+
+        // publisherDID is deliberately NOT validated. It belongs to the publisher, nothing in RACM
+        // looks this entity up by it, and duplicates may be intentional.
+
+        // getRootVolume() returns null, not an empty list, when nothing was ever attached
+        if (dcd.getRootVolume() == null)
+            return;
+
+        String path = rvm.getPathOnCD().trim();
+        String displayName = rvm.getDisplayName().trim();
+
+        for (RootVolumeOnComputeDomain existing : dcd.getRootVolume()) {
+            if (existing.getRootVolume() != null
+                    && rvm.getRootVolumeId().equals(existing.getRootVolume().getId()))
+                throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT, String.format(
+                        "Root volume %d is already mounted on this compute domain at '%s'",
+                        rvm.getRootVolumeId(), existing.getPath()));
+
+            if (path.equals(trimOrNull(existing.getPath())))
+                throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT, String.format(
+                        "Path '%s' is already in use on this compute domain", path));
+
+            if (displayName.equalsIgnoreCase(trimOrNull(existing.getDisplayName())))
+                throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT, String.format(
+                        "Display name '%s' is already in use on this compute domain", displayName));
+        }
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.trim().isEmpty();
+    }
+
+    private static String trimOrNull(String s) {
+        return s == null ? null : s.trim();
     }
 
     private DockerComputeDomain queryDockerComputeDomainForEndpoint(String endpoint,

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBMAccessControl.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBMAccessControl.java
@@ -50,4 +50,18 @@ public class JOBMAccessControl {
 	boolean canEditComputeDomain(User u, ComputeDomain cd) {
 		return racm.doesUserHaveRoleOnResource(u.getUsername(), cd.getResourceContext().getUuid(), RACMNames.CONTEXT_ROOTRESOURCE_PUBDID, RACMNames.R_COMPUTE_DOMAIN_ROOT_ADMIN);
 	}
+	/**
+	 * Return whether the user may mount a root volume on the specified compute domain.<br/>
+	 *
+	 * Unlike canEditComputeDomain, which asks for the whole root-admin role, this checks a single
+	 * action and can therefore be granted to a narrower role without code changes.
+	 *
+	 * @param up the user
+	 * @param cd the compute domain
+	 * @return true if the user holds the addRootVolume action on the domain's root context
+	 */
+	boolean canAddRootVolume(UserProfile up, ComputeDomain cd) {
+		return racm.canUserDoActionOnRootContext(up.getUsername(),
+				cd.getResourceContext().getUuid(), RACMNames.A_ADD_ROOT_VOLUME);
+	}
 }

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBMModelFactory.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBMModelFactory.java
@@ -642,15 +642,17 @@ public class JOBMModelFactory {
 		rvcd.setDisplayName(rvm.getDisplayName());
 		rvcd.setPath(rvm.getPathOnCD());
 		rvcd.setRootVolume(rv);
+		rvcd.setPublisherDID(rvm.getPublisherDID());
 		return rvcd;
 	}
 
-	private RootVolumeOnComputeDomainModel newRootVolumeOnComputeDomainModel(RootVolumeOnComputeDomain rv) {
+	public RootVolumeOnComputeDomainModel newRootVolumeOnComputeDomainModel(RootVolumeOnComputeDomain rv) {
 		RootVolumeOnComputeDomainModel rvm = new RootVolumeOnComputeDomainModel();
 		rvm.setDisplayName(rv.getDisplayName());
 		rvm.setPathOnCD(rv.getPath());
 		rvm.setRootVolumeId(rv.getRootVolume().getId());
 		rvm.setId(rv.getId());
+		rvm.setPublisherDID(rv.getPublisherDID());
 		return rvm;
 	}
 

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/controller/JOBMRESTController.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/controller/JOBMRESTController.java
@@ -18,6 +18,7 @@ import org.sciserver.racm.jobm.model.COMPMJobModel;
 import org.sciserver.racm.jobm.model.COMPMModel;
 import org.sciserver.racm.jobm.model.DockerComputeDomainModel;
 import org.sciserver.racm.jobm.model.JobQuery;
+import org.sciserver.racm.jobm.model.RootVolumeOnComputeDomainModel;
 import org.sciserver.racm.jobm.model.UserDockerComputeDomainModel;
 import org.sciserver.racm.utils.model.NativeQueryResult;
 import org.sciserver.springapp.racm.jobm.application.COMPMManager;
@@ -29,6 +30,7 @@ import org.sciserver.springapp.racm.ugm.application.UsersAndGroupsManager;
 import org.sciserver.springapp.racm.ugm.domain.UserProfile;
 import org.sciserver.springapp.racm.utils.RACMUtil;
 import org.sciserver.springapp.racm.utils.controller.JsonAPIHelper;
+import org.sciserver.springapp.racm.utils.controller.ResourceNotFoundException;
 import org.sciserver.springapp.racm.utils.http.HttpRequest;
 import org.sciserver.springapp.racm.utils.http.HttpResponseResult;
 import org.sciserver.springapp.racm.utils.logging.LogUtils;
@@ -51,6 +53,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import edu.jhu.job.DockerComputeDomain;
 import edu.jhu.job.DockerJob;
+import edu.jhu.job.RootVolumeOnComputeDomain;
 import edu.jhu.user.UserGroup;
 
 @CrossOrigin
@@ -384,6 +387,57 @@ public class JOBMRESTController {
         } catch (Exception e) {
             return jsonAPIHelper.logAndReturnJsonExceptionEntity(
                     "Error register a docker compute domain", Optional.of(up), e, true);
+        }
+    }
+
+    /**
+     * Attach a single root volume to an existing docker compute domain.
+     *
+     * <p>Unlike POST /computedomains/docker, this does not require resending the whole domain
+     * document and will not remove images, volume containers or other root volumes that are
+     * omitted from the request.
+     *
+     * @param racmUUID uuid of the compute domain's resource context
+     * @param rvm the root volume to attach
+     * @param up the calling user
+     * @return the created entry, including the id assigned by RACM
+     */
+    @PostMapping("/computedomains/docker/{racmUUID}/rootvolumes")
+    public ResponseEntity<JsonNode> addRootVolumeToDockerComputeDomain(
+            @PathVariable String racmUUID,
+            @RequestBody RootVolumeOnComputeDomainModel rvm,
+            @AuthenticationPrincipal UserProfile up) {
+        try {
+            RootVolumeOnComputeDomain rv =
+                    dockerComputeDomainManager.addRootVolume(racmUUID, rvm, up);
+            up.getTom().persist();
+
+            RootVolumeOnComputeDomainModel created =
+                    jobmModelFactory.newRootVolumeOnComputeDomainModel(rv);
+
+            LogUtils.buildLog()
+                .forJOBM()
+                .user(up)
+                .showInUserHistory()
+                .sentence()
+                    .subject(up.getUsername())
+                    .verb("mounted")
+                    .predicate("root volume %d at '%s' on docker compute domain '%s'",
+                            created.getRootVolumeId(), created.getPathOnCD(), racmUUID)
+                .extraField("dockerComputeDomain", racmUUID)
+                .extraField("rootVolume", created.getRootVolumeId())
+                .extraField("rootVolumeOnComputeDomain", created.getId())
+                .log();
+
+            return jsonAPIHelper.success(created);
+        } catch (ResourceNotFoundException e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "No docker compute domain with racmUUID " + racmUUID,
+                    Optional.of(up), e, HttpStatus.NOT_FOUND, true);
+        } catch (Exception e) {
+            return jsonAPIHelper.logAndReturnJsonExceptionEntity(
+                    "Error adding root volume to docker compute domain " + racmUUID,
+                    Optional.of(up), e, true);
         }
     }
 

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/utils/RACMNames.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/utils/RACMNames.java
@@ -42,6 +42,7 @@ public class RACMNames {
 	public static final String A_CREATE_DOCKER_CONTAINER = "createDockerContainer";
 	public static final String A_REGISTER_VOLUME_CONTAINER = "registerVolumeContainer";
 	public static final String A_REGISTER_DOCKER_IMAGE = "registerDockerImage";
+	public static final String A_ADD_ROOT_VOLUME = "addRootVolume";
 
 	// PublicVolume ResourceType
 	public static final String RT_VOLUME_CONTAINER = "VolumeContainer";

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/utils/controller/JsonAPIHelper.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/utils/controller/JsonAPIHelper.java
@@ -36,21 +36,32 @@ public class JsonAPIHelper {
 
 	public ResponseEntity<JsonNode> logAndReturnJsonExceptionEntity(
 			String text, Optional<UserProfile> up, Exception e, boolean isJOBM) {
-		HttpStatus http;
+		return logAndReturnJsonExceptionEntity(text, up, e, statusFor(e), isJOBM);
+	}
+
+	/**
+	 * Maps an exception to the HTTP status it should be reported as.
+	 *
+	 * <p>Note VOURPException.ILLEGAL_STATE deliberately maps to 500: those sites signal a violated
+	 * server-side invariant, which is what a 500 is for.
+	 *
+	 * @param e the exception to map
+	 * @return the HTTP status to report
+	 */
+	static HttpStatus statusFor(Exception e) {
 		if (e instanceof RACMException)
-			http = HttpStatus.UNAUTHORIZED;
-		else if (e instanceof InsufficientPermissionsException) {
-			http = HttpStatus.FORBIDDEN;
-		} else if (e instanceof VOURPException) {
+			return HttpStatus.UNAUTHORIZED;
+		if (e instanceof InsufficientPermissionsException)
+			return HttpStatus.FORBIDDEN;
+		if (e instanceof VOURPException) {
 			int error = ((VOURPException) e).getErrorCode();
 			if (error == VOURPException.ILLEGAL_ARGUMENT)
-				http = HttpStatus.BAD_REQUEST;
-			else
-				http = HttpStatus.INTERNAL_SERVER_ERROR;
-		} else {
-			http = HttpStatus.INTERNAL_SERVER_ERROR;
+				return HttpStatus.BAD_REQUEST;
+			if (error == VOURPException.UNAUTHORIZED)
+				return HttpStatus.FORBIDDEN;
+			return HttpStatus.INTERNAL_SERVER_ERROR;
 		}
-		return logAndReturnJsonExceptionEntity(text, up, e, http, isJOBM);
+		return HttpStatus.INTERNAL_SERVER_ERROR;
 	}
 
 	public ResponseEntity<JsonNode> logAndReturnJsonExceptionEntity(

--- a/components/java/racm/src/main/resources/db/migration/V35__add_addRootVolume_action.sql
+++ b/components/java/racm/src/main/resources/db/migration/V35__add_addRootVolume_action.sql
@@ -1,0 +1,46 @@
+-- Adds an 'addRootVolume' action to the root context of the DockerComputeDomain context class,
+-- so that mounting a root volume on a compute domain can be authorized independently of the
+-- blanket 'admin' role, and grants it to the existing compute domain admin role so that current
+-- administrators keep the ability they have today.
+--
+-- Note: t_RoleAction.containerId is the ROLE id; actionId is the ACTION id.
+-- The t_Role join is anchored to the resource type, not just the role name: V1 seeds several
+-- roles named 'admin' on different resource types, and matching on name alone would bind this
+-- action to the wrong one, silently.
+--
+-- Inserts target the t_ tables rather than the unprefixed views, because the views omit OPTLOCK.
+--
+-- Both statements are guarded with NOT EXISTS so the script is safe to re-run.
+
+INSERT [dbo].[t_Action]
+    ([DTYPE], [OPTLOCK], [publisherDID], [containerId], [name], [description], [category])
+    SELECT 'Action', 1, NULL, rt.ID, 'addRootVolume',
+           'Action of mounting a root volume on this compute domain.', 'C'
+      FROM t_ContextClass cc
+      INNER JOIN t_ResourceType rt
+              ON rt.containerId = cc.ID
+             AND rt.[name] = '__rootcontext__'
+     WHERE cc.[name] = 'DockerComputeDomain'
+       AND NOT EXISTS (SELECT 1
+                         FROM t_Action a
+                        WHERE a.containerId = rt.ID
+                          AND a.[name] = 'addRootVolume')
+
+INSERT [dbo].[t_RoleAction]
+    ([DTYPE], [OPTLOCK], [publisherDID], [containerId], [actionId])
+    SELECT 'RoleAction', 1, NULL, r.ID, a.ID
+      FROM t_ContextClass cc
+      INNER JOIN t_ResourceType rt
+              ON rt.containerId = cc.ID
+             AND rt.[name] = '__rootcontext__'
+      INNER JOIN t_Role r
+              ON r.containerId = rt.ID
+             AND r.[name] = 'admin'
+      INNER JOIN t_Action a
+              ON a.containerId = rt.ID
+             AND a.[name] = 'addRootVolume'
+     WHERE cc.[name] = 'DockerComputeDomain'
+       AND NOT EXISTS (SELECT 1
+                         FROM t_RoleAction ra
+                        WHERE ra.containerId = r.ID
+                          AND ra.actionId = a.ID)

--- a/components/java/racm/src/test/java/org/sciserver/springapp/racm/jobm/application/DockerComputeDomainManagerTests.java
+++ b/components/java/racm/src/test/java/org/sciserver/springapp/racm/jobm/application/DockerComputeDomainManagerTests.java
@@ -1,0 +1,111 @@
+package org.sciserver.springapp.racm.jobm.application;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.persistence.Query;
+
+import org.ivoa.dm.VOURPException;
+import org.ivoa.dm.model.TransientObjectManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.sciserver.racm.jobm.model.RootVolumeOnComputeDomainModel;
+import org.sciserver.springapp.racm.ugm.domain.UserProfile;
+import org.sciserver.springapp.racm.utils.controller.ResourceNotFoundException;
+
+import edu.jhu.job.DockerComputeDomain;
+import edu.jhu.job.RootVolumeOnComputeDomain;
+
+public class DockerComputeDomainManagerTests {
+    private static final String RACM_UUID = "3f9a1c2e-8b04-4d17-9e55-1a2b3c4d5e6f";
+    private static final Long ROOT_VOLUME_ID = 17L;
+
+    private final JOBMAccessControl accessControl = mock(JOBMAccessControl.class);
+    private final JOBMModelFactory modelFactory = mock(JOBMModelFactory.class);
+    private final ComputeDomainManager computeDomainManager = mock(ComputeDomainManager.class);
+    private final DockerComputeDomainManager manager =
+            new DockerComputeDomainManager(accessControl, modelFactory, computeDomainManager);
+
+    private final UserProfile up = mock(UserProfile.class);
+    private final TransientObjectManager tom = mock(TransientObjectManager.class);
+    private final Query query = mock(Query.class);
+
+    @Before
+    public void setUp() {
+        when(up.getTom()).thenReturn(tom);
+        when(up.getUsername()).thenReturn("someuser");
+        when(tom.createQuery(anyString())).thenReturn(query);
+        when(query.setParameter(anyString(), any())).thenReturn(query);
+    }
+
+    /** Registers a compute domain as the one the uuid lookup will find, and authorizes the user. */
+    private DockerComputeDomain authorizedDomain() {
+        DockerComputeDomain dcd = mock(DockerComputeDomain.class);
+        when(dcd.getApiEndpoint()).thenReturn("https://example.org/racm");
+        when(tom.queryOne(query, DockerComputeDomain.class)).thenReturn(dcd);
+        when(accessControl.canAddRootVolume(up, dcd)).thenReturn(true);
+        return dcd;
+    }
+
+    private RootVolumeOnComputeDomainModel validModel() {
+        RootVolumeOnComputeDomainModel m = new RootVolumeOnComputeDomainModel();
+        m.setRootVolumeId(ROOT_VOLUME_ID);
+        m.setPathOnCD("/home/idies/workspace/Storage");
+        m.setDisplayName("Storage");
+        return m;
+    }
+
+    @Test
+    public void unknownRacmUUIDIsNotFound() {
+        when(tom.queryOne(query, DockerComputeDomain.class)).thenReturn(null);
+
+        try {
+            manager.addRootVolume(RACM_UUID, validModel(), up);
+            fail("expected ResourceNotFoundException");
+        } catch (ResourceNotFoundException expected) {
+            // pass
+        } catch (VOURPException e) {
+            fail("expected ResourceNotFoundException, got " + e);
+        }
+    }
+
+    @Test
+    public void unauthorizedUserIsRejectedAndNothingIsCreated() throws Exception {
+        DockerComputeDomain dcd = mock(DockerComputeDomain.class);
+        when(dcd.getApiEndpoint()).thenReturn("https://example.org/racm");
+        when(tom.queryOne(query, DockerComputeDomain.class)).thenReturn(dcd);
+        when(accessControl.canAddRootVolume(up, dcd)).thenReturn(false);
+
+        try {
+            manager.addRootVolume(RACM_UUID, validModel(), up);
+            fail("expected VOURPException");
+        } catch (VOURPException expected) {
+            assertEquals(VOURPException.UNAUTHORIZED, expected.getErrorCode());
+        }
+
+        verify(modelFactory, never()).newRootVolumeOnComputeDomain(any(), any());
+    }
+
+    @Test
+    public void validRequestDelegatesToTheFactoryAndDoesNotPersist() throws Exception {
+        DockerComputeDomain dcd = authorizedDomain();
+        RootVolumeOnComputeDomain created = mock(RootVolumeOnComputeDomain.class);
+        RootVolumeOnComputeDomainModel model = validModel();
+        when(modelFactory.newRootVolumeOnComputeDomain(model, dcd)).thenReturn(created);
+
+        RootVolumeOnComputeDomain result = manager.addRootVolume(RACM_UUID, model, up);
+
+        assertSame(created, result);
+        verify(modelFactory).newRootVolumeOnComputeDomain(model, dcd);
+        // The transaction belongs to the controller. RACM uses no @Transactional; managers mutate
+        // and the controller calls tom.persist(). Persisting here would break that contract.
+        verify(tom, never()).persist();
+    }
+}

--- a/components/java/racm/src/test/java/org/sciserver/springapp/racm/jobm/application/DockerComputeDomainManagerTests.java
+++ b/components/java/racm/src/test/java/org/sciserver/springapp/racm/jobm/application/DockerComputeDomainManagerTests.java
@@ -1,6 +1,7 @@
 package org.sciserver.springapp.racm.jobm.application;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -9,6 +10,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
 
 import javax.persistence.Query;
 
@@ -20,6 +24,7 @@ import org.sciserver.racm.jobm.model.RootVolumeOnComputeDomainModel;
 import org.sciserver.springapp.racm.ugm.domain.UserProfile;
 import org.sciserver.springapp.racm.utils.controller.ResourceNotFoundException;
 
+import edu.jhu.file.RootVolume;
 import edu.jhu.job.DockerComputeDomain;
 import edu.jhu.job.RootVolumeOnComputeDomain;
 
@@ -107,5 +112,142 @@ public class DockerComputeDomainManagerTests {
         // The transaction belongs to the controller. RACM uses no @Transactional; managers mutate
         // and the controller calls tom.persist(). Persisting here would break that contract.
         verify(tom, never()).persist();
+    }
+
+    /** Builds a mock existing entry on the domain. Any argument may be null. */
+    private RootVolumeOnComputeDomain existingEntry(Long rootVolumeId, String path, String displayName) {
+        RootVolumeOnComputeDomain rv = mock(RootVolumeOnComputeDomain.class);
+        if (rootVolumeId != null) {
+            RootVolume target = mock(RootVolume.class);
+            when(target.getId()).thenReturn(rootVolumeId);
+            when(rv.getRootVolume()).thenReturn(target);
+        }
+        when(rv.getPath()).thenReturn(path);
+        when(rv.getDisplayName()).thenReturn(displayName);
+        return rv;
+    }
+
+    private void withExistingEntries(DockerComputeDomain dcd, RootVolumeOnComputeDomain... entries) {
+        List<RootVolumeOnComputeDomain> list = Arrays.asList(entries);
+        when(dcd.getRootVolume()).thenReturn(list);
+    }
+
+    /** Asserts that the call fails with ILLEGAL_ARGUMENT and that nothing was created. */
+    private void assertRejected(RootVolumeOnComputeDomainModel model) throws Exception {
+        try {
+            manager.addRootVolume(RACM_UUID, model, up);
+            fail("expected VOURPException(ILLEGAL_ARGUMENT)");
+        } catch (VOURPException expected) {
+            assertEquals(VOURPException.ILLEGAL_ARGUMENT, expected.getErrorCode());
+        }
+        verify(modelFactory, never()).newRootVolumeOnComputeDomain(any(), any());
+    }
+
+    @Test
+    public void suppliedIdIsRejected() throws Exception {
+        authorizedDomain();
+        RootVolumeOnComputeDomainModel model = validModel();
+        model.setId(99L);
+
+        assertRejected(model);
+    }
+
+    @Test
+    public void missingRootVolumeIdIsRejected() throws Exception {
+        authorizedDomain();
+        RootVolumeOnComputeDomainModel model = validModel();
+        model.setRootVolumeId(null);
+
+        assertRejected(model);
+    }
+
+    @Test
+    public void blankPathIsRejected() throws Exception {
+        authorizedDomain();
+        RootVolumeOnComputeDomainModel model = validModel();
+        model.setPathOnCD("   ");
+
+        assertRejected(model);
+    }
+
+    @Test
+    public void missingDisplayNameIsRejected() throws Exception {
+        authorizedDomain();
+        RootVolumeOnComputeDomainModel model = validModel();
+        model.setDisplayName(null);
+
+        assertRejected(model);
+    }
+
+    @Test
+    public void mountingTheSameRootVolumeTwiceIsRejected() throws Exception {
+        DockerComputeDomain dcd = authorizedDomain();
+        withExistingEntries(dcd, existingEntry(ROOT_VOLUME_ID, "/somewhere/else", "Other"));
+
+        assertRejected(validModel());
+    }
+
+    @Test
+    public void duplicatePathIsRejected() throws Exception {
+        DockerComputeDomain dcd = authorizedDomain();
+        withExistingEntries(dcd,
+                existingEntry(999L, "/home/idies/workspace/Storage", "Other"));
+
+        assertRejected(validModel());
+    }
+
+    @Test
+    public void duplicateDisplayNameDifferingOnlyInCaseIsRejected() throws Exception {
+        DockerComputeDomain dcd = authorizedDomain();
+        withExistingEntries(dcd, existingEntry(999L, "/somewhere/else", "sTORAGE"));
+
+        assertRejected(validModel());
+    }
+
+    /**
+     * Deliberate absence of validation. publisherDID belongs to the publisher: nothing in RACM
+     * looks this entity up by it, and duplicates may be intentional. If you are here because you
+     * "fixed" a missing uniqueness check, read design v5 D12 first -- this test failing means the
+     * decision was reversed, not that a bug was found.
+     */
+    @Test
+    public void duplicatePublisherDIDIsAllowed() throws Exception {
+        DockerComputeDomain dcd = authorizedDomain();
+        RootVolumeOnComputeDomain existing = existingEntry(999L, "/somewhere/else", "Other");
+        when(existing.getPublisherDID()).thenReturn("ivo://example.org/thing");
+        withExistingEntries(dcd, existing);
+
+        RootVolumeOnComputeDomainModel model = validModel();
+        model.setPublisherDID("ivo://example.org/thing");
+        RootVolumeOnComputeDomain created = mock(RootVolumeOnComputeDomain.class);
+        when(modelFactory.newRootVolumeOnComputeDomain(model, dcd)).thenReturn(created);
+
+        assertNotNull(manager.addRootVolume(RACM_UUID, model, up));
+    }
+
+    /** getRootVolume() returns null, not an empty list, until something has been attached. */
+    @Test
+    public void domainWithNoRootVolumesIsAccepted() throws Exception {
+        DockerComputeDomain dcd = authorizedDomain();
+        when(dcd.getRootVolume()).thenReturn(null);
+
+        RootVolumeOnComputeDomainModel model = validModel();
+        RootVolumeOnComputeDomain created = mock(RootVolumeOnComputeDomain.class);
+        when(modelFactory.newRootVolumeOnComputeDomain(model, dcd)).thenReturn(created);
+
+        assertNotNull(manager.addRootVolume(RACM_UUID, model, up));
+    }
+
+    /** The new invariants do not hold retroactively: legacy rows may have null fields. */
+    @Test
+    public void existingEntryWithNullDisplayNameDoesNotBreakValidation() throws Exception {
+        DockerComputeDomain dcd = authorizedDomain();
+        withExistingEntries(dcd, existingEntry(999L, null, null));
+
+        RootVolumeOnComputeDomainModel model = validModel();
+        RootVolumeOnComputeDomain created = mock(RootVolumeOnComputeDomain.class);
+        when(modelFactory.newRootVolumeOnComputeDomain(model, dcd)).thenReturn(created);
+
+        assertNotNull(manager.addRootVolume(RACM_UUID, model, up));
     }
 }

--- a/components/java/racm/src/test/java/org/sciserver/springapp/racm/jobm/application/JOBMAccessControlTests.java
+++ b/components/java/racm/src/test/java/org/sciserver/springapp/racm/jobm/application/JOBMAccessControlTests.java
@@ -1,0 +1,58 @@
+package org.sciserver.springapp.racm.jobm.application;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.sciserver.springapp.racm.ugm.domain.UserProfile;
+import org.sciserver.springapp.racm.utils.RACM;
+import org.sciserver.springapp.racm.utils.RACMNames;
+
+import edu.jhu.job.DockerComputeDomain;
+import edu.jhu.rac.ResourceContext;
+
+public class JOBMAccessControlTests {
+    private static final String CONTEXT_UUID = "3f9a1c2e-8b04-4d17-9e55-1a2b3c4d5e6f";
+
+    private final RACM racm = mock(RACM.class);
+    private final JOBMAccessControl accessControl = new JOBMAccessControl(racm);
+
+    private DockerComputeDomain domainWithContext() {
+        ResourceContext rc = mock(ResourceContext.class);
+        when(rc.getUuid()).thenReturn(CONTEXT_UUID);
+        DockerComputeDomain dcd = mock(DockerComputeDomain.class);
+        when(dcd.getResourceContext()).thenReturn(rc);
+        return dcd;
+    }
+
+    private UserProfile user() {
+        UserProfile up = mock(UserProfile.class);
+        when(up.getUsername()).thenReturn("someuser");
+        return up;
+    }
+
+    @Test
+    public void canAddRootVolumeChecksTheAddRootVolumeActionOnTheDomainsRootContext() {
+        when(racm.canUserDoActionOnRootContext("someuser", CONTEXT_UUID, RACMNames.A_ADD_ROOT_VOLUME))
+                .thenReturn(true);
+
+        assertTrue(accessControl.canAddRootVolume(user(), domainWithContext()));
+    }
+
+    @Test
+    public void canAddRootVolumeIsFalseWhenTheActionIsNotGranted() {
+        when(racm.canUserDoActionOnRootContext("someuser", CONTEXT_UUID, RACMNames.A_ADD_ROOT_VOLUME))
+                .thenReturn(false);
+
+        assertFalse(accessControl.canAddRootVolume(user(), domainWithContext()));
+    }
+
+    @Test
+    public void actionNameIsAddRootVolume() {
+        // The V35 migration inserts this literal into t_Action; the two must agree.
+        assertEquals("addRootVolume", RACMNames.A_ADD_ROOT_VOLUME);
+    }
+}

--- a/components/java/racm/src/test/java/org/sciserver/springapp/racm/jobm/application/JOBMModelFactoryTests.java
+++ b/components/java/racm/src/test/java/org/sciserver/springapp/racm/jobm/application/JOBMModelFactoryTests.java
@@ -1,0 +1,86 @@
+package org.sciserver.springapp.racm.jobm.application;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import javax.persistence.Query;
+
+import org.ivoa.dm.VOURPException;
+import org.ivoa.dm.model.TransientObjectManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.sciserver.racm.jobm.model.RootVolumeOnComputeDomainModel;
+import org.sciserver.springapp.racm.utils.VOURPContext;
+
+import edu.jhu.file.RootVolume;
+import edu.jhu.job.DockerComputeDomain;
+import edu.jhu.job.RootVolumeOnComputeDomain;
+
+/**
+ * Pins the publisherDID round-trip for RootVolumeOnComputeDomain. This pair was the only
+ * entity/model pair in the factory that silently dropped publisherDID in both directions.
+ */
+public class JOBMModelFactoryTests {
+    private static final Long ROOT_VOLUME_ID = 17L;
+    private static final String PUBLISHER_DID = "ivo://sciserver.org/computedomain/1#storage";
+
+    private final JOBMAccessControl accessControl = mock(JOBMAccessControl.class);
+    private final VOURPContext vourpContext = mock(VOURPContext.class);
+    private final JOBMModelFactory factory = new JOBMModelFactory(accessControl, vourpContext);
+
+    private final TransientObjectManager tom = mock(TransientObjectManager.class);
+    private final Query query = mock(Query.class);
+    private DockerComputeDomain domain;
+
+    @Before
+    public void setUp() {
+        when(tom.createQuery(anyString())).thenReturn(query);
+        when(query.setParameter(anyString(), any())).thenReturn(query);
+
+        RootVolume rootVolume = mock(RootVolume.class);
+        when(rootVolume.getId()).thenReturn(ROOT_VOLUME_ID);
+        when(tom.queryOne(query, RootVolume.class)).thenReturn(rootVolume);
+
+        domain = mock(DockerComputeDomain.class);
+        when(domain.getTom()).thenReturn(tom);
+    }
+
+    private RootVolumeOnComputeDomainModel model(String publisherDID) {
+        RootVolumeOnComputeDomainModel m = new RootVolumeOnComputeDomainModel();
+        m.setRootVolumeId(ROOT_VOLUME_ID);
+        m.setPathOnCD("/home/idies/workspace/Storage");
+        m.setDisplayName("Storage");
+        m.setPublisherDID(publisherDID);
+        return m;
+    }
+
+    @Test
+    public void publisherDIDIsCarriedOntoTheEntity() throws VOURPException {
+        RootVolumeOnComputeDomain entity = factory.newRootVolumeOnComputeDomain(model(PUBLISHER_DID), domain);
+
+        assertEquals(PUBLISHER_DID, entity.getPublisherDID());
+    }
+
+    @Test
+    public void absentPublisherDIDLeavesTheEntityNull() throws VOURPException {
+        RootVolumeOnComputeDomain entity = factory.newRootVolumeOnComputeDomain(model(null), domain);
+
+        assertNull(entity.getPublisherDID());
+    }
+
+    @Test
+    public void publisherDIDIsReadBackIntoTheModel() throws VOURPException {
+        RootVolumeOnComputeDomain entity = factory.newRootVolumeOnComputeDomain(model(PUBLISHER_DID), domain);
+
+        RootVolumeOnComputeDomainModel rendered = factory.newRootVolumeOnComputeDomainModel(entity);
+
+        assertEquals(PUBLISHER_DID, rendered.getPublisherDID());
+        assertEquals("/home/idies/workspace/Storage", rendered.getPathOnCD());
+        assertEquals("Storage", rendered.getDisplayName());
+        assertEquals(ROOT_VOLUME_ID, rendered.getRootVolumeId());
+    }
+}

--- a/components/java/racm/src/test/java/org/sciserver/springapp/racm/utils/controller/JsonAPIHelperTests.java
+++ b/components/java/racm/src/test/java/org/sciserver/springapp/racm/utils/controller/JsonAPIHelperTests.java
@@ -1,0 +1,52 @@
+package org.sciserver.springapp.racm.utils.controller;
+
+import static org.junit.Assert.assertEquals;
+
+import org.ivoa.dm.VOURPException;
+import org.junit.Test;
+import org.sciserver.springapp.racm.login.InsufficientPermissionsException;
+import org.sciserver.springapp.racm.utils.RACMException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Pins the exception-to-HTTP-status mapping. This mapping has silently drifted once
+ * already: VOURPException.UNAUTHORIZED used to fall through to 500.
+ */
+public class JsonAPIHelperTests {
+
+    @Test
+    public void illegalArgumentMapsToBadRequest() {
+        assertEquals(HttpStatus.BAD_REQUEST,
+                JsonAPIHelper.statusFor(new VOURPException(VOURPException.ILLEGAL_ARGUMENT, "bad input")));
+    }
+
+    @Test
+    public void unauthorizedMapsToForbidden() {
+        assertEquals(HttpStatus.FORBIDDEN,
+                JsonAPIHelper.statusFor(new VOURPException(VOURPException.UNAUTHORIZED, "not allowed")));
+    }
+
+    @Test
+    public void illegalStateMapsToInternalServerError() {
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR,
+                JsonAPIHelper.statusFor(new VOURPException(VOURPException.ILLEGAL_STATE, "invariant violated")));
+    }
+
+    @Test
+    public void racmExceptionMapsToUnauthorized() {
+        assertEquals(HttpStatus.UNAUTHORIZED,
+                JsonAPIHelper.statusFor(new RACMException("someuser", "some-resource-uuid", "someAction")));
+    }
+
+    @Test
+    public void insufficientPermissionsMapsToForbidden() {
+        assertEquals(HttpStatus.FORBIDDEN,
+                JsonAPIHelper.statusFor(new InsufficientPermissionsException("do something")));
+    }
+
+    @Test
+    public void unrecognisedExceptionMapsToInternalServerError() {
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR,
+                JsonAPIHelper.statusFor(new IllegalStateException("boom")));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `POST /jobm/rest/computedomains/docker/{racmUUID}/rootvolumes`, which attaches one root volume
to a docker compute domain.

Today the only way to do this is `POST /computedomains/docker` with a full `DockerComputeDomainModel`,
which routes through `synchronizeRootVolumes` and **deletes any image, volume container or root
volume the caller omits**. This endpoint avoids that.

Six self-contained commits; each builds and tests green on its own.

## What reviewers should look at

Three changes reach beyond the new endpoint. Each is deliberate, and each is the reason the work is
split into separate commits rather than one.

### 1. `a0a86c2` — `VOURPException(UNAUTHORIZED)` now maps to 403 instead of 500

`JsonAPIHelper` mapped only `ILLEGAL_ARGUMENT` to 400; every other VO-URP code fell through to 500.
So permission denials were reported as internal server errors, indistinguishable from real faults in
logs and alerting.

**Blast radius, measured:** 20 `UNAUTHORIZED` throw sites exist; **18 change from 500 to 403**. The
other two are in `QueryMvcController`, which bypasses `JsonAPIHelper` entirely. `ILLEGAL_ARGUMENT`
(55 sites) and `ILLEGAL_STATE` (7) are unaffected.

Nothing in this repository distinguishes the two statuses: `clients/utils` wraps any non-2xx without
branching, the single `httpCode()` branch outside racm targets the auth service, and
`dashboard/error-handler.js` special-cases 401 only. **Worth checking SciScript-Python / SciScript-R
for 5xx-specific handling**, and warning whoever owns alerting that 5xx volume will drop.

### 2. `8fdba14` — new `addRootVolume` action, delivered by `V35`

Authorization uses a dedicated RACM action rather than the blanket `canEditComputeDomain` role check,
so it can be granted to a narrower role later without code changes.

**The `t_RoleAction` insert is the grandfathering mechanism.** Role to action bindings are global on
the ContextClass while role assignments are per-domain, so that single row is what keeps every
existing compute-domain admin working. Without it the new check returns false for everyone.

The role join is anchored to the resource type, not the role name: `V1` seeds several roles named
`admin` on different resource types, and matching on name alone would bind the action to the wrong
one silently.

Note `initDockerComputeDomainCC` is **not** touched. It looks like the place to register actions but
is never called - `V1__Base_version.sql` seeds the context classes directly. Adding correct code to a
dead method would imply a second working path that does not exist.

**This migration must be applied before the endpoint is usable.** Verified against a database copy,
including that an existing admin gains the action.

### 3. `84b9bda` — `publisherDID` round-trip fix, wider than the new endpoint

Every other entity/model pair in `JOBMModelFactory` carries `publisherDID` across. The
`RootVolumeOnComputeDomain` pair was the only one that dropped it, in both directions - never written
on create, never read back, so a caller-supplied value was silently discarded.

Because both methods are shared, this also affects existing endpoints:

- `POST /computedomains/docker` now persists `publisherDID` for root volumes
- `GET /dockercomputedomains` responses gain a `publisherDID` field per root volume entry

Both additive: the field was always null before, so nothing that works today can break.

## API

```
POST /jobm/rest/computedomains/docker/{racmUUID}/rootvolumes
```

| Field | Required | Notes |
|---|---|---|
| `rootVolumeId` | yes | VO-URP id of an existing `RootVolume` |
| `pathOnCD` | yes | unique within the domain |
| `displayName` | yes | unique within the domain, case-insensitive |
| `publisherDID` | no | recorded verbatim, **not** validated for uniqueness |
| `id` | must be absent | rejected with 400; RACM assigns it |

Returns `200` with the created entry including its assigned `id`.

`id` is rejected rather than ignored because silently ignoring it hands the caller a `200` and an
entity whose id is not the one they sent - most likely a `GET` payload replayed into a create call.

`publisherDID` is deliberately not policed: it belongs to the publisher, nothing in RACM looks this
entity up by it, and no other entity is checked this way. A negative test asserts duplicates are
accepted, so the decision cannot be reversed by accident.

No new DTO, so `racm_models.jar` is unchanged.

## Tests

**47 tests, 0 failures** - 25 new, and the 22 pre-existing ones still green. These are the first
tests in the `jobm` package.

Three encode conventions rather than behaviour, and are the ones worth keeping:

- the manager does **not** call `tom.persist()` - RACM has no `@Transactional`; controllers own the transaction
- a domain whose collection getter returns `null` (not empty) still works
- legacy rows with null fields do not break the new validation - these invariants are not retroactive

## Not covered by automated tests

RACM has no MockMvc harness, so path mapping, JSON binding and the auth filter chain are unverified
by CI. Manually exercised against a local database copy: the happy path, every validation rejection,
404 on an unknown uuid, and the `publisherDID` round-trip.

## Interaction with the existing endpoint

`POST /computedomains/docker` is unchanged and still works. `ComputeDomainManager` has no diff in
this branch, and `updateDockerComputeDomain` still calls `synchronizeRootVolumes` exactly as before.

Two things it does inherit, both from shared code rather than logic changes:

- auth failures return **403 instead of 500** - it throws `VOURPException(UNAUTHORIZED)`, so it is one
  of the 18 sites in `a0a86c2`
- it now persists `publisherDID` for newly created root volume entries, which were previously
  dropped, and `GET /dockercomputedomains` returns the field

**Worth knowing:** the old endpoint remains full-replace, so it will silently delete root volumes
added through the new one if they are absent from its payload:

```java
// anything on the domain not mentioned in the submitted list
for (RootVolumeOnComputeDomain rv : rvs.values())
    cd.getRootVolume().remove(rv);
```

That behaviour is not new, but there are now two paths that write root volumes, so it is newly
reachable: attach one via the new endpoint, then have another tool run an old-style update built
from a stale document, and the entry disappears with no error. The defence is the one callers should
already follow - `GET` the domain immediately before, and send the full list back.

Also unchanged, and arguably the larger gap: `synchronizeRootVolumes` only ever **creates or
deletes**. For an entry matched by id it keeps the entity untouched, never updating `path`,
`displayName` or `publisherDID`. So there is still no way to *edit* an existing root volume mount
through either endpoint - only remove and re-add, and removal currently needs the destructive
full-replace or direct SQL.

That is the case for the follow-ups below: a `DELETE .../rootvolumes/{id}`, and probably a
`PATCH .../rootvolumes/{id}` alongside it. Together they would make the full-replace POST
unnecessary for root volumes entirely.

## Follow-ups, deliberately out of scope

- `DELETE .../rootvolumes/{id}` - the URL shape leaves room for it; attaching is currently one-way
- Replacing the 56 controller-level `try/catch` blocks with `@ControllerAdvice` handling. Sized and
  deferred: it cannot be done by deleting them, since `RACMErrorHandler` has no `VOURPException`
  handler and all 55 `ILLEGAL_ARGUMENT` sites would regress to 500
- `RACMErrorAttributes` is dead code - its `@Override` is commented out and its signature is the
  Spring Boot 1.x one. Pre-existing, untouched here
