### PR TITLE
Make job command box scrollable + extract shared CommandBox

### DIFF
--- a/components/ui/web/components/common/commandBox.tsx
+++ b/components/ui/web/components/common/commandBox.tsx
@@ -1,0 +1,83 @@
+import { FC, useState } from 'react';
+import styled from 'styled-components';
+import { IconButton, Snackbar } from '@mui/material';
+import {
+  ContentCopy as ContentCopyIcon,
+  Close as CloseIcon
+} from '@mui/icons-material';
+
+type Props = {
+  command: string;
+  width?: string;
+  maxHeight?: string;
+};
+
+const Styled = styled.div<{ width: string; maxHeight: string }>`
+  width: ${props => props.width};
+
+  pre {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    background: #000;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    color: #ddd;
+    font-family: monospace;
+    font-size: 12px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    max-height: ${props => props.maxHeight};
+    overflow: auto;
+
+    line-height: 1.6;
+    padding: 1em 1.5em;
+  }
+
+  .copy-icon {
+    padding-left: 5rem;
+    position: sticky;
+    top: 0;
+  }
+`;
+
+export const CommandBox: FC<Props> = ({ command, width = '100%', maxHeight = '40vh' }) => {
+
+  const [copiedSnackbarOpen, setCopiedSnackbarOpen] = useState(false);
+
+  return <Styled className="command" {...{ width, maxHeight }}>
+    <pre>
+      {command}
+      <IconButton
+        className="copy-icon"
+        size="small"
+        aria-label="copy"
+        color="inherit"
+        onClick={() => {
+          navigator.clipboard.writeText(command);
+          setCopiedSnackbarOpen(true);
+        }}
+      >
+        <ContentCopyIcon fontSize="medium" />
+      </IconButton>
+    </pre>
+    <Snackbar
+      open={copiedSnackbarOpen}
+      autoHideDuration={5000}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      onClose={() => setCopiedSnackbarOpen(false)}
+      message="Copied to clipboard!"
+      action={<>
+        <IconButton
+          size="small"
+          aria-label="close"
+          color="inherit"
+          onClick={() => setCopiedSnackbarOpen(false)}
+        >
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </>}
+    />
+  </Styled>;
+};

--- a/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
+++ b/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
@@ -44,26 +44,32 @@ const Styled = styled.div`
 
   .command {
     width: 80%;
-    
+
     pre {
       display: flex;
       justify-content: space-between;
-      align-items: center;
+      align-items: flex-start;
       background: #000;
       border: 1px solid #ddd;
       border-radius: 5px;
       color: #ddd;
       font-family: monospace;
       font-size: 12px;
-      text-wrap: wrap;
-      
+      white-space: pre-wrap;
+      word-break: break-word;
+      overflow-wrap: anywhere;
+      max-height: 40vh;
+      overflow: auto;
+
       line-height: 1.6;
       padding: 1em 1.5em;
     }
   }
-    
+
   .copy-icon {
     padding-left: 5rem;
+    position: sticky;
+    top: 0;
   }
 
   .html-description{

--- a/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
+++ b/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
@@ -5,11 +5,9 @@ import { useRouter } from 'next/router';
 import { useMutation, useQuery } from '@apollo/client';
 import styled from 'styled-components';
 
-import { IconButton, Snackbar, Tooltip } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import {
   ArrowBackIos as ArrowBackIcon,
-  ContentCopy as ContentCopyIcon,
-  Close as CloseIcon,
   Download as DownloadIcon,
   Replay as ReplayIcon
 } from '@mui/icons-material';
@@ -25,6 +23,7 @@ import { File, Job, JobDetails } from 'src/graphql/typings';
 import { CREATE_JOB, JOB_DETAIL_VIEW } from 'src/graphql/jobs';
 
 import { CustomizedTabs } from 'components/common/tabs';
+import { CommandBox } from 'components/common/commandBox';
 import { LoadingAnimation } from 'components/common/loadingAnimation';
 import { jobStatusAllowRerun } from 'components/content/jobs/list/RerunJobAction';
 
@@ -40,36 +39,6 @@ const Styled = styled.div`
       gap: 1rem;
       align-items: center;
     }
-  }
-
-  .command {
-    width: 80%;
-
-    pre {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      background: #000;
-      border: 1px solid #ddd;
-      border-radius: 5px;
-      color: #ddd;
-      font-family: monospace;
-      font-size: 12px;
-      white-space: pre-wrap;
-      word-break: break-word;
-      overflow-wrap: anywhere;
-      max-height: 40vh;
-      overflow: auto;
-
-      line-height: 1.6;
-      padding: 1em 1.5em;
-    }
-  }
-
-  .copy-icon {
-    padding-left: 5rem;
-    position: sticky;
-    top: 0;
   }
 
   .html-description{
@@ -114,7 +83,6 @@ export const JobFullDetail: FC = () => {
   const { id } = router.query;
 
   const [tabValue, setTabValue] = useState<number>(0);
-  const [copiedSnackbarOpen, setCopiedSnackbarOpen] = useState(false);
 
   const { loading, data } = useQuery(JOB_DETAIL_VIEW,
     {
@@ -280,40 +248,7 @@ export const JobFullDetail: FC = () => {
           }
         </div>
         {jobDetail.job.command &&
-          <div className="command">
-            <pre>
-              {jobDetail.job.command}
-              <IconButton
-                className="copy-icon"
-                size="small"
-                aria-label="close"
-                color="inherit"
-                onClick={() => {
-                  navigator.clipboard.writeText(jobDetail.job.command);
-                  setCopiedSnackbarOpen(true);
-                }}
-              >
-                <ContentCopyIcon fontSize="medium" />
-              </IconButton>
-            </pre>
-            <Snackbar
-              open={copiedSnackbarOpen}
-              autoHideDuration={5000}
-              anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-              onClose={() => setCopiedSnackbarOpen(false)}
-              message="Copied to clipboard!"
-              action={<>
-                <IconButton
-                  size="small"
-                  aria-label="close"
-                  color="inherit"
-                  onClick={() => setCopiedSnackbarOpen(false)}
-                >
-                  <CloseIcon fontSize="small" />
-                </IconButton>
-              </>}
-            />
-          </div>
+          <CommandBox command={jobDetail.job.command} width="80%" />
         }
         <CustomizedTabs tabs={tabOptions} value={tabValue} setValue={setTabValue} />
         <div>

--- a/components/ui/web/components/content/jobs/detail/jobShortDetail.tsx
+++ b/components/ui/web/components/content/jobs/detail/jobShortDetail.tsx
@@ -1,17 +1,15 @@
-import { FC, useState } from 'react';
+import { FC } from 'react';
 import styled from 'styled-components';
 import {
   Button,
   IconButton,
-  Snackbar,
   Drawer
 } from '@mui/material';
-import {
-  ContentCopy as ContentCopyIcon,
-  Close as CloseIcon
-} from '@mui/icons-material';
+import { Close as CloseIcon } from '@mui/icons-material';
 import { Job } from 'src/graphql/typings';
 import { useRouter } from 'next/router';
+
+import { CommandBox } from 'components/common/commandBox';
 
 const StyledDrawer = styled(Drawer)`
   .MuiDrawer-paper {
@@ -31,7 +29,7 @@ const StyledDrawer = styled(Drawer)`
   .job-details {
     display: flex;
     gap: 3rem;
-    
+
     .job-field {
       display : flex;
       flex-direction: column;
@@ -43,42 +41,12 @@ const StyledDrawer = styled(Drawer)`
       }
     }
   }
-  
+
   .actions {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
   }
-
-
-  .command {
-    pre {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      background: #000;
-      border: 1px solid #ddd;
-      border-radius: 5px;
-      color: #ddd;
-      font-family: monospace;
-      font-size: 12px;
-      white-space: pre-wrap;
-      word-break: break-word;
-      overflow-wrap: anywhere;
-      max-height: 30vh;
-      overflow: auto;
-
-      line-height: 1.6;
-      padding: 1em 1.5em;
-    }
-  }
-
-  .copy-icon {
-    padding-left: 5rem;
-    position: sticky;
-    top: 0;
-  }
-  
 `;
 
 type Props = {
@@ -90,7 +58,6 @@ type Props = {
 export const JobShortDetail: FC<Props> = ({ job, isOpen, setOpenRow }) => {
 
   const router = useRouter();
-  const [copiedSnackbarOpen, setCopiedSnackbarOpen] = useState(false);
 
   return <StyledDrawer
     anchor="bottom"
@@ -148,40 +115,7 @@ export const JobShortDetail: FC<Props> = ({ job, isOpen, setOpenRow }) => {
       </div>
     </div>
     {job.command &&
-      <div className="command">
-        <pre>
-          {job.command}
-          <IconButton
-            className="copy-icon"
-            size="small"
-            aria-label="copy"
-            color="inherit"
-            onClick={() => {
-              navigator.clipboard.writeText(job.command);
-              setCopiedSnackbarOpen(true);
-            }}
-          >
-            <ContentCopyIcon fontSize="medium" />
-          </IconButton>
-        </pre>
-        <Snackbar
-          open={copiedSnackbarOpen}
-          autoHideDuration={5000}
-          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-          onClose={() => setCopiedSnackbarOpen(false)}
-          message="Copied to clipboard!"
-          action={<>
-            <IconButton
-              size="small"
-              aria-label="close"
-              color="inherit"
-              onClick={() => setCopiedSnackbarOpen(false)}
-            >
-              <CloseIcon fontSize="small" />
-            </IconButton>
-          </>}
-        />
-      </div>
+      <CommandBox command={job.command} maxHeight="30vh" />
     }
   </StyledDrawer>;
 };

--- a/components/ui/web/components/content/jobs/detail/jobShortDetail.tsx
+++ b/components/ui/web/components/content/jobs/detail/jobShortDetail.tsx
@@ -55,22 +55,28 @@ const StyledDrawer = styled(Drawer)`
     pre {
       display: flex;
       justify-content: space-between;
-      align-items: center;
+      align-items: flex-start;
       background: #000;
       border: 1px solid #ddd;
       border-radius: 5px;
       color: #ddd;
       font-family: monospace;
       font-size: 12px;
-      text-wrap: wrap;
-      
+      white-space: pre-wrap;
+      word-break: break-word;
+      overflow-wrap: anywhere;
+      max-height: 30vh;
+      overflow: auto;
+
       line-height: 1.6;
       padding: 1em 1.5em;
     }
   }
-    
+
   .copy-icon {
     padding-left: 5rem;
+    position: sticky;
+    top: 0;
   }
   
 `;


### PR DESCRIPTION
## Description

This PR closes #128 

- The job command box (rendered from `job.command`) had no height cap and used the unreliable `text-wrap: wrap`, so a long command grew the box unbounded. It now caps its height and scrolls, wraps reliably (`white-space: pre-wrap` + `word-break` / `overflow-wrap`), and keeps the copy button reachable via `position: sticky`.
- The command box markup (scrollable `<pre>`, copy-to-clipboard button, "Copied to clipboard!" snackbar) was duplicated between the job **short detail** drawer and the job **full detail** page. Extracted it into `components/common/commandBox.tsx` and both now consume it.

## Why

Improvised fix for the short detail view since the MUI Data Grid Pro row-detail panel isn't available — a bottom `Drawer` is used instead, and long commands made it unusable. Same overflow issue existed on the full detail page.


## Screenshots

1. Full detail Job screen command box's height gets capped and becomes scrollable
<img width="1134" height="738" alt="image" src="https://github.com/user-attachments/assets/cb91e62f-7a86-423d-8c92-96d71b2885b6" />

<img width="1134" height="738" alt="image" src="https://github.com/user-attachments/assets/3f2fb1c7-9f7d-4c5b-ada7-0d792b421171" />

2. Short detail Job drawer command box's height gets capped and becomes scrollable

<img width="1290" height="753" alt="image" src="https://github.com/user-attachments/assets/48d67c2b-a00b-4776-be89-7c333b2f40ef" />
<img width="1290" height="753" alt="image" src="https://github.com/user-attachments/assets/10edd251-2a92-42f2-8126-2112210e07ff" />
