### PR TITLE
[HOTFIX] Job Full Detail component wasn't displaying correctly 

### DIFF
--- a/components/ui/graphql/src/data/jobs.ts
+++ b/components/ui/graphql/src/data/jobs.ts
@@ -14,8 +14,7 @@ import {
   JobDetails,
   JobFilters,
   JobMessage,
-  JobsResponse,
-  JobStatus
+  JobsResponse
 } from '../generated/typings';
 
 export class JobsAPI extends RESTDataSource {
@@ -67,14 +66,14 @@ export class JobsAPI extends RESTDataSource {
 
     let files: File[] = [];
     let summary = 'No summary available';
-    // only attempt to get files and summary if job is successful or failed,
-    // otherwise the results folder may not exist and we will get an error
-    if (job.resultsFolderURI.length && (job.status === JobStatus.Success || job.status === JobStatus.Error)) {
+    // Load files and summary whenever the job has a results folder. Not gated on
+    // job.status - RACM does not reliably report a bare 'SUCCESS'/'ERROR' string
+    // here, which was silently emptying this view.
+    if (job.resultsFolderURI.length) {
       const sanitizedURI = job.resultsFolderURI.replace('/home/idies/workspace/', '');
-      const jobJsontree = await this.volumesAPI.getFilesByVolume(sanitizedURI) || {};
-      files = jobJsontree.root.files || [];
-      const readMeFile = await this.get(`${this.filesURL}file/${sanitizedURI}/README.md`) || {};
-      summary = readMeFile;
+      const jobJsontree = await this.volumesAPI.getFilesByVolume(sanitizedURI);
+      files = jobJsontree?.root?.files || [];
+      summary = await this.get(`${this.filesURL}file/${sanitizedURI}/README.md`) || summary;
     }
 
     return {

--- a/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
+++ b/components/ui/web/components/content/jobs/detail/jobFullDetail.tsx
@@ -106,12 +106,18 @@ export const JobFullDetail: FC = () => {
 
   const router = useRouter();
   const { id } = router.query;
+  const jobId = Array.isArray(id) ? id[0] : id;
 
   const [tabValue, setTabValue] = useState<number>(0);
   const [copiedSnackbarOpen, setCopiedSnackbarOpen] = useState(false);
 
   const { loading, data } = useQuery(JOB_DETAIL_VIEW,
     {
+      // On a hard page reload of /jobs/[id], router.query is empty until the
+      // router is ready. Skip the query until we actually have a job id,
+      // otherwise it fires with jobId: undefined and the server rejects it
+      // ("Variable \"$jobId\" of required type \"ID!\" was not provided").
+      skip: !router.isReady || !jobId,
       onError: (error) => Swal.fire({
         title: 'There was an error loading the job details',
         text: error.message,
@@ -120,7 +126,7 @@ export const JobFullDetail: FC = () => {
       }).then(() => {
         router.push('/jobs');
       }).catch(Error),
-      variables: { jobId: id }
+      variables: { jobId }
     }
   );
 
@@ -329,8 +335,8 @@ export const JobFullDetail: FC = () => {
         </div>
       </div>
     }
-    {loading &&
-      <LoadingAnimation backDropIsOpen={loading} />
+    {(loading || !router.isReady) &&
+      <LoadingAnimation backDropIsOpen />
     }
   </Styled>;
 };


### PR DESCRIPTION
## Description 
**Fix job full-detail view: empty Files/Summary and reload error**

Fixes two regressions on `/jobs/[id]`:

- **Files tab and summary were always empty.** `getJobDetails` gated the files/summary fetch on `job.status === 'SUCCESS' | 'ERROR'`, but RACM doesn't return that bare string, so the check never passed. Removed the gate — the fetch now runs whenever the job has a `resultsFolderURI`. Also hardened the response parsing (optional chaining on the jsontree, string fallback for the README so `summary` stays a valid `String!`).

- **Hard reload threw "Variable $jobId of required type ID! was not provided" and redirected to `/jobs`.** The query fired before `router.query` was populated. Added `skip: !router.isReady || !jobId` and normalized the route param.