### PR TITLE
Require domain rights and service token when registering a database context

### DIFF
--- a/components/java/clients/racm/src/main/java/org/sciserver/racm/client/RACMClient.java
+++ b/components/java/clients/racm/src/main/java/org/sciserver/racm/client/RACMClient.java
@@ -336,14 +336,15 @@ public class RACMClient extends Client<RACMClientInterface> {
      * @param databaseContextModel basic information about the new Database Context
      * @param admins comma-separated list of groups to have admin privileges for the context
      * @param userToken token
+     * @param serviceToken service account token of the RDB Compute Domain identified by domainId
      * @return Newly registered DatabaseContextModel with fields populated by RACM
      *
      * @throws SciServerClientException in case of bad response or IO issue
      */
     public DatabaseContextModel registerRDBComputeDbContext(Long domainId, DatabaseContextModel databaseContextModel,
-            String admins, String userToken) throws SciServerClientException {
+            String admins, String userToken, String serviceToken) throws SciServerClientException {
         Call<DatabaseContextModel> call = retrofitAdapter.registerRDBComputeDbContextCall(domainId,
-                databaseContextModel, admins, userToken);
+                databaseContextModel, admins, userToken, serviceToken);
         return getSyncResponse(call);
     }
 

--- a/components/java/clients/racm/src/main/java/org/sciserver/racm/client/RACMClientInterface.java
+++ b/components/java/clients/racm/src/main/java/org/sciserver/racm/client/RACMClientInterface.java
@@ -154,7 +154,8 @@ public interface RACMClientInterface {
     @POST("jobm/rest/computedomains/rdb/{domainId}")
     Call<DatabaseContextModel> registerRDBComputeDbContextCall(@Path("domainId") Long domainId,
             @Body DatabaseContextModel databaseContextModel, @Query("admins") String admins,
-            @Header(Client.AUTH_TOKEN_HEADER) String userToken);
+            @Header(Client.AUTH_TOKEN_HEADER) String userToken,
+            @Header(Client.SERVICE_TOKEN_HEADER) String serviceToken);
 
     @GET("jobm/rest/computedomains")
     Call<List<UserDockerComputeDomainModel>> getUserComputeDomainsCall(

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBMAccessControl.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/JOBMAccessControl.java
@@ -50,4 +50,7 @@ public class JOBMAccessControl {
 	boolean canEditComputeDomain(User u, ComputeDomain cd) {
 		return racm.doesUserHaveRoleOnResource(u.getUsername(), cd.getResourceContext().getUuid(), RACMNames.CONTEXT_ROOTRESOURCE_PUBDID, RACMNames.R_COMPUTE_DOMAIN_ROOT_ADMIN);
 	}
+	boolean canRegisterDatabaseContext(User u, ComputeDomain cd) {
+		return racm.canUserDoActionOnRootContext(u.getUsername(), cd.getResourceContext().getUuid(), RACMNames.A_REGISTER_DATABASE_CONTEXT);
+	}
 }

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/RDBDomainManager.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/application/RDBDomainManager.java
@@ -115,10 +115,10 @@ public class RDBDomainManager {
             throw new VOURPException(VOURPException.ILLEGAL_ARGUMENT,
                     String.format("No RDB compute domain with id=%s exists", domainId.toString()));
         }
-        // Check if user is allowed to update the computedomain, must have admin role on it
-        if (!jobmAccessControl.canEditComputeDomain(up.getUser(), rdbcd)) {
+        // Check if user has the right to register a database context on the computedomain
+        if (!jobmAccessControl.canRegisterDatabaseContext(up.getUser(), rdbcd)) {
             throw new VOURPException(VOURPException.UNAUTHORIZED, String.format(
-                    "User %s is not authorized to update the RDBComputeDomain with apiEndpoint '%s'",
+                    "User %s is not authorized to register a DatabaseContext on the RDBComputeDomain with apiEndpoint '%s'",
                     up.getUsername(), rdbcd.getApiEndpoint()));
         }
 

--- a/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/controller/RDBJobRESTController.java
+++ b/components/java/racm/src/main/java/org/sciserver/springapp/racm/jobm/controller/RDBJobRESTController.java
@@ -238,16 +238,23 @@ public class RDBJobRESTController {
 	 * @param body  JSON representation of a DatabaseContext to be added to the specified domain
 	 * @param admins  if set, give admin privileges to the groups in the comma-separated value
      * @param up  representation of the user submitting the requested DatabaseContext
+     * @param serviceAccountToken  service account token of the RDBComputeDomain being targeted
 	 * @return
 	 * @throws VOURPException
 	 */
 	@PostMapping("/computedomains/rdb/{domainId}")
 	public ResponseEntity<JsonNode> registerRDBComputeDbContext(@PathVariable Long domainId, @RequestBody String body,
-			@RequestParam(required = false) String admins, @AuthenticationPrincipal UserProfile up)
+			@RequestParam(required = false) String admins, @AuthenticationPrincipal UserProfile up,
+			@RequestHeader(name = X_SERVICE_ID, required = true) String serviceAccountToken)
 			throws VOURPException {
 		DatabaseContextModel dbcm = null;
 
         try {
+			RDBComputeDomain rdbcd = rdbDomainManager.getRDBComputeDomain(serviceAccountToken);
+			if (rdbcd == null || !rdbcd.getId().equals(domainId))
+				throw new VOURPException(VOURPException.UNAUTHORIZED,
+						"This request must have a service account corresponding to the domain that is targeted");
+
 			jobm.buildTrustIfNeeded(up.getUser(), up.getToken());
 			ObjectMapper mapper = RACMUtil.newObjectMapper();
 			ObjectNode node = mapper.readValue(body, ObjectNode.class);


### PR DESCRIPTION
Changes:

1. Authorization: addDbContextToRDBComputeDomain now checks the registerDatabaseContext right on the domain's root context (new JOBMAccessControl.canRegisterDatabaseContext) instead of testing for the admin role by name. 

2. Authentication: the endpoint now requires the X-Service-Auth-ID header and rejects it unless it resolves to the domain in the path, same as submitJob. RACMClient.registerRDBComputeDbContext gained a serviceToken param as well.

Callers now need both the domain's service token and the register right, when only a plain user token used to be enough in the past.